### PR TITLE
Add support for basic auth and other fixes

### DIFF
--- a/openapitor/src/functions.rs
+++ b/openapitor/src/functions.rs
@@ -953,6 +953,12 @@ fn get_function_body(
                         query_params.push((#name, p));
                     }
                 })
+            } else if type_text == "crate::types::phone_number::PhoneNumber" {
+                optional_params.push(quote! {
+                    if let Some(p) = #name_ident.0 {
+                        query_params.push((#name, format!("{p}")));
+                    }
+                })
             } else if t.is_option_vec()? {
                 optional_params.push(quote! {
                     if let Some(p) = #name_ident {
@@ -1097,6 +1103,8 @@ fn get_function_body(
 
     let bearer_auth = if opts.token_endpoint.is_some() {
         quote!(req = req.bearer_auth(&self.client.token.read().await.access_token);)
+    } else if opts.basic_auth {
+        quote!(req = req.basic_auth(&self.client.username, Some(&self.client.password));)
     } else {
         quote!(req = req.bearer_auth(&self.client.token);)
     };

--- a/openapitor/src/template.rs
+++ b/openapitor/src/template.rs
@@ -100,7 +100,11 @@ fn generate_docs_openapi_info(spec: &openapiv3::OpenAPI, opts: &crate::Opts) -> 
     let api_version = format!("based on API spec version `{}`", spec.info.version);
 
     let spec_link_blurb = if let Some(link) = &opts.spec_url {
-        format!("This client is generated from the [OpenAPI specs]({}) {}. This way it will remain up to date as features are added.", link, api_version)
+        format!(
+            "This client is generated from the [OpenAPI specs]({}) {}. This way it will remain up \
+             to date as features are added.",
+            link, api_version
+        )
     } else {
         "".to_string()
     };
@@ -188,6 +192,55 @@ pub fn generate_docs(spec: &openapiv3::OpenAPI, opts: &crate::Opts) -> Result<St
             opts.version,
             opts.code_package_name(),
             get_env_variable_prefix(&opts.name),
+            get_env_variable_prefix(&opts.name),
+            get_env_variable_prefix(&opts.name),
+            opts.code_package_name(),
+        ));
+    }
+
+    if opts.basic_auth {
+        return Ok(format!(
+            r#"{}
+//!
+//! To install the library, add the following to your `Cargo.toml` file.
+//!
+//! ```toml
+//! [dependencies]
+//! {} = "{}"
+//! ```
+//!
+//! ## Basic example
+//!
+//! Typical use will require intializing a `Client`. This requires
+//! a user agent string and set of credentials.
+//!
+//! ```rust,no_run
+//! use {}::Client;
+//!
+//! let client = Client::new(
+//!     String::from("username"),
+//!     String::from("password"),
+//! );
+//! ```
+//!
+//! Alternatively, the library can search for most of the variables required for
+//! the client in the environment:
+//!
+//! - `{}_USERNAME`
+//! - `{}_PASSWORD`
+//!
+//! And then you can create a client from the environment.
+//!
+//! ```rust,no_run
+//! use {}::Client;
+//!
+//! let client = Client::new_from_env();
+//! ```
+//!"#,
+            info,
+            opts.package_name(),
+            opts.version,
+            opts.code_package_name(),
             get_env_variable_prefix(&opts.name),
             get_env_variable_prefix(&opts.name),
             opts.code_package_name(),

--- a/openapitor/src/tests.rs
+++ b/openapitor/src/tests.rs
@@ -46,9 +46,7 @@ async fn test_kittycad_generation(ctx: &mut TestContext) {
         description: "KittyCAD is a tool for generating 3D models of cats.".to_string(),
         spec_url: Some("https://api.kittycad.io".to_string()),
         repo_name: Some("kittycad/kittycad.rs".to_string()),
-        token_endpoint: None,
-        user_consent_endpoint: None,
-        date_time_format: None,
+        ..Default::default()
     };
 
     // Load our spec.
@@ -98,9 +96,7 @@ async fn test_github_generation(ctx: &mut TestContext) {
         description: "GitHub is where we push our code and you do too!".to_string(),
         spec_url: Some("https://github.com/github/rest-api-description/raw/main/descriptions/api.github.com/api.github.com.json".to_string()),
         repo_name: Some("kittycad/octorust.rs".to_string()),
-        token_endpoint:None,
-        user_consent_endpoint:None,
-        date_time_format: None,
+        ..Default::default()
     };
 
     // Load our spec.
@@ -136,9 +132,7 @@ async fn test_oxide_generation(ctx: &mut TestContext) {
                 .to_string(),
         ),
         repo_name: Some("oxide/oxide.rs".to_string()),
-        token_endpoint: None,
-        user_consent_endpoint: None,
-        date_time_format: None,
+        ..Default::default()
     };
 
     // Load our spec.
@@ -172,9 +166,7 @@ async fn test_front_generation(ctx: &mut TestContext) {
         description: "CRM crap!".to_string(),
         spec_url: Some("".to_string()),
         repo_name: Some("kittycad/front.rs".to_string()),
-        token_endpoint: None,
-        user_consent_endpoint: None,
-        date_time_format: None,
+        ..Default::default()
     };
 
     // Load our spec.
@@ -209,7 +201,7 @@ async fn test_gusto_generation(ctx: &mut TestContext) {
         repo_name: Some("kittycad/gusto.rs".to_string()),
         token_endpoint: Some("https://api.gusto.com/oauth/token".parse().unwrap()),
         user_consent_endpoint: Some("https://api.gusto.com/oauth/authorize".parse().unwrap()),
-        date_time_format: None,
+        ..Default::default()
     };
 
     // Load our spec.

--- a/openapitor/src/types/exts.rs
+++ b/openapitor/src/types/exts.rs
@@ -529,9 +529,10 @@ pub trait OperationExt {
 
 impl OperationExt for openapiv3::Operation {
     fn get_tag(&self) -> Result<String> {
-        Ok(crate::clean_tag_name(self.tags.first().ok_or_else(
-            || anyhow::anyhow!("operation  has no tags: {:?}", self),
-        )?))
+        match self.tags.first() {
+            Some(tag) => Ok(crate::clean_tag_name(tag)),
+            None => Ok("default".to_string()),
+        }
     }
 
     fn get_fn_name(&self) -> Result<String> {


### PR DESCRIPTION
We could prob do some cleanup to make the client gen less repetitive, but for now, I went the easy route and duplicated.

Twilio doesn't tag any of their endpoints, so we just assign them all to default and generate a client with that.