### PR TITLE
fix #154: openapitor was outputting invalid docstrings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oncemutex"
@@ -1060,6 +1060,7 @@ dependencies = [
  "json-patch",
  "log",
  "numeral",
+ "once_cell",
  "openapiv3",
  "phonenumber",
  "pretty_assertions",

--- a/openapitor/Cargo.toml
+++ b/openapitor/Cargo.toml
@@ -41,6 +41,7 @@ thiserror = "1"
 tokio = { version = "1.20.1", features = ["full"] }
 url = { version = "^2.2.2", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v4"] }
+once_cell = "1.17.1"
 
 [dev-dependencies]
 async-trait = "^0.1.56"

--- a/openapitor/src/tests.rs
+++ b/openapitor/src/tests.rs
@@ -220,6 +220,45 @@ async fn test_gusto_generation(ctx: &mut TestContext) {
     run_cargo_test(&opts).await.unwrap();
 }
 
+#[test_context(TestContext)]
+#[tokio::test]
+async fn test_ramp_generation(ctx: &mut TestContext) {
+    let opts = crate::Opts {
+        debug: true,
+        json: false,
+        input: ctx.tmp_dir.clone(),
+        output: ctx.tmp_dir.clone(),
+        base_url: "https://api.ramp.com".parse().unwrap(),
+        name: "ramp-api".to_string(),
+        version: "1.0.0".to_string(),
+        description: " crap!".to_string(),
+        spec_url: Some("".to_string()),
+        repo_name: Some("kittycad/ramp.rs".to_string()),
+        token_endpoint: Some(
+            "https://api.ramp.com/v1/public/customer/token"
+                .parse()
+                .unwrap(),
+        ),
+        user_consent_endpoint: Some("https://app.ramp.com/v1/authorize".parse().unwrap()),
+        ..Default::default()
+    };
+
+    // Load our spec.
+    let spec = crate::load_yaml_spec(include_str!("../tests/ramp.json")).unwrap();
+
+    // Move our test file to our output directory.
+    let test_file = include_str!("../tests/library/ramp.tests.rs");
+    // Write our temporary file.
+    let test_file_path = ctx.tmp_dir.join("src").join("tests.rs");
+    std::fs::write(&test_file_path, test_file).unwrap();
+
+    // Generate the library.
+    crate::generate(&spec, &opts).await.unwrap();
+
+    // Run tests.
+    run_cargo_test(&opts).await.unwrap();
+}
+
 async fn run_cargo_test(opts: &crate::Opts) -> Result<()> {
     log::info!("Running `cargo test`...");
 

--- a/openapitor/tests/ramp.json
+++ b/openapitor/tests/ramp.json
@@ -1,0 +1,5701 @@
+{
+    "servers": [
+        {
+            "url": "https://api.ramp.com",
+            "description": "Production"
+        }
+    ],
+    "paths": {
+        "/developer/v1/business/": {
+            "get": {
+                "tags": [
+                    "Business"
+                ],
+                "operationId": "get_business_resource",
+                "responses": {
+                    "400": {
+                        "description": "raises BusinessInvalidInput"
+                    },
+                    "200": {
+                        "description": "Get business information",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Business"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "business:read"
+                        ]
+                    }
+                ],
+                "summary": "Fetch the company metadata associated with the OAuth2 access token"
+            }
+        },
+        "/developer/v1/business/balance": {
+            "get": {
+                "tags": [
+                    "Business"
+                ],
+                "operationId": "get_business_balance_resource",
+                "responses": {
+                    "200": {
+                        "description": "Get business balance information",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BusinessBalance"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "business:read"
+                        ]
+                    }
+                ],
+                "summary": "Retrieve the current balance info of a business"
+            }
+        },
+        "/developer/v1/cards/{card_id}": {
+            "get": {
+                "tags": [
+                    "Card"
+                ],
+                "operationId": "get_card_resource",
+                "responses": {
+                    "400": {
+                        "description": "raises CardInvalidInput"
+                    },
+                    "200": {
+                        "description": "Get single card",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Card"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "cards:read"
+                        ]
+                    }
+                ],
+                "summary": "Fetch a single card by ID"
+            },
+            "patch": {
+                "tags": [
+                    "Card"
+                ],
+                "operationId": "patch_card_resource",
+                "responses": {
+                    "400": {
+                        "description": "raises CardInvalidInput"
+                    },
+                    "204": {
+                        "description": "Update a single card"
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "cards:write"
+                        ]
+                    }
+                ],
+                "summary": "Updates a card's spending restrictions",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiCardUpdate"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "card_id",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/cards/{card_id}/deferred/termination": {
+            "post": {
+                "tags": [
+                    "Card"
+                ],
+                "operationId": "post_card_termination_resource",
+                "responses": {
+                    "400": {
+                        "description": "raises CardInvalidInput"
+                    },
+                    "200": {
+                        "description": "Response with the ID of the async task. Task status can be checked via a GET call to .../deferred/status/<task_id>",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DeferredTaskUUID"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "cards:write"
+                        ]
+                    }
+                ],
+                "summary": "Create an async task to terminate a card permanently",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiCardDeferredUpdate"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "card_id",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/cards/{card_id}/deferred/suspension": {
+            "post": {
+                "tags": [
+                    "Card"
+                ],
+                "operationId": "post_card_suspension_resource",
+                "responses": {
+                    "400": {
+                        "description": "raises CardInvalidInput"
+                    },
+                    "200": {
+                        "description": "Response with the ID of the async task. Task status can be checked via a GET call to .../deferred/status/<task_id>",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DeferredTaskUUID"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "cards:write"
+                        ]
+                    }
+                ],
+                "summary": "Create an async task to suspend a card so that it is locked from use",
+                "description": "The suspension is revertable.",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiCardDeferredUpdate"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "card_id",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/cards/{card_id}/deferred/unsuspension": {
+            "post": {
+                "tags": [
+                    "Card"
+                ],
+                "operationId": "post_card_unsuspension_resource",
+                "responses": {
+                    "400": {
+                        "description": "raises CardInvalidInput"
+                    },
+                    "200": {
+                        "description": "Response with the ID of the async task. Task status can be checked via a GET call to .../deferred/status/<task_id>",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DeferredTaskUUID"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "cards:write"
+                        ]
+                    }
+                ],
+                "summary": "Create an async task to remove a card's suspension so that it may be used again",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiCardDeferredUpdate"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "card_id",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/cards/": {
+            "get": {
+                "tags": [
+                    "Card"
+                ],
+                "operationId": "get_card_list_with_pagination",
+                "responses": {
+                    "400": {
+                        "description": "raises CardInvalidInput"
+                    },
+                    "200": {
+                        "description": "Cards",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedResponseApiCardResourceSchema"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "cards:read"
+                        ]
+                    }
+                ],
+                "summary": "Retrieve all cards",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "user_id",
+                        "required": false,
+                        "description": "Filter by card owner.",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "is_activated",
+                        "required": false,
+                        "description": "Filter only for activated cards. Defaults to True if not specified",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "card_program_id",
+                        "required": false,
+                        "description": "Filter by card program.",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "required": false,
+                        "description": "The number of results to be returned in each page. The value must be between 2 and 10,000. If not specified, the default value 1,000 will be used.",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1000,
+                            "minimum": 2,
+                            "maximum": 10000
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "start",
+                        "required": false,
+                        "description": "The ID of the last entity of the previous page, used for pagination to get the next page.",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ]
+            }
+        },
+        "/developer/v1/cards/deferred/physical": {
+            "post": {
+                "tags": [
+                    "Card"
+                ],
+                "operationId": "post_physical_card",
+                "responses": {
+                    "200": {
+                        "description": "Response with the ID of the async task. Task status can be checked via a GET call to .../deferred/status/<task_id>",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DeferredTaskUUID"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "cards:write"
+                        ]
+                    }
+                ],
+                "summary": "Create a physical card",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiCardRequest"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/developer/v1/cards/deferred/virtual": {
+            "post": {
+                "tags": [
+                    "Card"
+                ],
+                "operationId": "post_virtual_card",
+                "responses": {
+                    "200": {
+                        "description": "Response with the ID of the async task. Task status can be checked via a GET call to .../deferred/status/<task_id>",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DeferredTaskUUID"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "cards:write"
+                        ]
+                    }
+                ],
+                "summary": "Create a virtual card",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiCardRequest"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/developer/v1/cards/deferred/status/{task_uuid}": {
+            "get": {
+                "tags": [
+                    "Card"
+                ],
+                "operationId": "get_card_deferred_task_resource",
+                "responses": {
+                    "200": {
+                        "description": "Card deferred task status",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CardDeferredTask"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "cards:write"
+                        ]
+                    }
+                ],
+                "summary": "Gets the status of a deferred task for cards"
+            },
+            "parameters": [
+                {
+                    "name": "task_uuid",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/card-programs/{card_program_id}": {
+            "get": {
+                "tags": [
+                    "Card Program"
+                ],
+                "operationId": "get_card_program_resource",
+                "responses": {
+                    "200": {
+                        "description": "Get single card program",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiCardProgramResource"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "card_programs:read"
+                        ]
+                    }
+                ],
+                "summary": "Retrieve the card program by ID"
+            },
+            "parameters": [
+                {
+                    "name": "card_program_id",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/card-programs/": {
+            "get": {
+                "tags": [
+                    "Card Program"
+                ],
+                "operationId": "get_card_program_list",
+                "responses": {
+                    "200": {
+                        "description": "CardPrograms",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedResponseApiCardProgramResourceSchema"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "card_programs:read"
+                        ]
+                    }
+                ],
+                "summary": "List all the card programs",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "required": false,
+                        "description": "The number of results to be returned in each page. The value must be between 2 and 10,000. If not specified, the default value 1,000 will be used.",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1000,
+                            "minimum": 2,
+                            "maximum": 10000
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "start",
+                        "required": false,
+                        "description": "The ID of the last entity of the previous page, used for pagination to get the next page.",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Card Program"
+                ],
+                "operationId": "post_card_program_list",
+                "responses": {
+                    "201": {
+                        "description": "Create Card Program",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiCardProgramResource"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "card_programs:write"
+                        ]
+                    }
+                ],
+                "summary": "Create a new card program",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiCardProgramCreate"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/developer/v1/custom-id-provider/": {
+            "get": {
+                "tags": [
+                    "Custom Id Provider"
+                ],
+                "operationId": "get_custom_id_provider_endpoint",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CustomIdProvider"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [],
+                "summary": "Get provider id associated with access token"
+            },
+            "post": {
+                "tags": [
+                    "Custom Id Provider"
+                ],
+                "operationId": "post_custom_id_provider_endpoint",
+                "responses": {
+                    "201": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CustomIdProvider"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [],
+                "summary": "Create custom id provider"
+            }
+        },
+        "/developer/v1/custom-id-provider/application-link": {
+            "post": {
+                "tags": [
+                    "Custom Id Provider"
+                ],
+                "operationId": "post_custom_id_provider_token_endpoint",
+                "responses": {
+                    "204": {
+                        "description": "Success, No content"
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [],
+                "summary": "Register an access token with custom id provider",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiCustomIdProviderTokenCreate"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/developer/v1/custom-id-provider/{entity_type}/{custom_id}/ramp-id": {
+            "get": {
+                "tags": [
+                    "Custom Id Provider"
+                ],
+                "operationId": "get_ramp_id_resource",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RampId"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [],
+                "summary": "Get ramp id from corresponding custom id"
+            },
+            "parameters": [
+                {
+                    "name": "entity_type",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                },
+                {
+                    "name": "custom_id",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/custom-id-provider/{entity_type}/{ramp_id}/custom-id": {
+            "get": {
+                "tags": [
+                    "Custom Id Provider"
+                ],
+                "operationId": "get_ramp_to_custom_id",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CustomId"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [],
+                "summary": "Get custom id from corresponding ramp id"
+            },
+            "parameters": [
+                {
+                    "name": "entity_type",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                },
+                {
+                    "name": "ramp_id",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/custom-id-provider/{entity_type}/custom-id-link": {
+            "post": {
+                "tags": [
+                    "Custom Id Provider"
+                ],
+                "operationId": "post_create_custom_id_mapping",
+                "responses": {
+                    "201": {
+                        "description": "Success"
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [],
+                "summary": "Add custom id <-> ramp id mapping",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiCustomIdMapping"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "entity_type",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/departments/{department_uuid}": {
+            "get": {
+                "tags": [
+                    "Department"
+                ],
+                "operationId": "get_department_resource",
+                "responses": {
+                    "200": {
+                        "description": "Department",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Department"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "departments:read"
+                        ]
+                    }
+                ],
+                "summary": "Retrieve a single department by ID"
+            },
+            "patch": {
+                "tags": [
+                    "Department"
+                ],
+                "operationId": "patch_department_resource",
+                "responses": {
+                    "200": {
+                        "description": "Department",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Department"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "departments:write"
+                        ]
+                    }
+                ],
+                "summary": "Modify a department",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiDepartmentUpdate"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "department_uuid",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/departments/": {
+            "get": {
+                "tags": [
+                    "Department"
+                ],
+                "operationId": "get_department_list_with_pagination",
+                "responses": {
+                    "400": {
+                        "description": "raises DepartmentInvalidInput"
+                    },
+                    "200": {
+                        "description": "Departments",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedResponseApiDepartmentResourceSchema"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "departments:read"
+                        ]
+                    }
+                ],
+                "summary": "Retrieve all departments",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "required": false,
+                        "description": "The number of results to be returned in each page. The value must be between 2 and 10,000. If not specified, the default value 1,000 will be used.",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1000,
+                            "minimum": 2,
+                            "maximum": 10000
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "start",
+                        "required": false,
+                        "description": "The ID of the last entity of the previous page, used for pagination to get the next page.",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Department"
+                ],
+                "operationId": "post_department_list_with_pagination",
+                "responses": {
+                    "400": {
+                        "description": "raises DepartmentInvalidInput"
+                    },
+                    "200": {
+                        "description": "Department",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Department"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "departments:write"
+                        ]
+                    }
+                ],
+                "summary": "Create a new department",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiDepartmentCreate"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/developer/v1/locations/{location_uuid}": {
+            "get": {
+                "tags": [
+                    "Location"
+                ],
+                "operationId": "get_location_single_resource",
+                "responses": {
+                    "200": {
+                        "description": "Location",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Location"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "locations:read"
+                        ]
+                    }
+                ],
+                "summary": "Retrieve a specific location by ID"
+            },
+            "patch": {
+                "tags": [
+                    "Location"
+                ],
+                "operationId": "patch_location_single_resource",
+                "responses": {
+                    "200": {
+                        "description": "Location",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Location"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "locations:write"
+                        ]
+                    }
+                ],
+                "summary": "Modifies a location",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiLocationUpdate"
+                            }
+                        }
+                    }
+                }
+            },
+            "parameters": [
+                {
+                    "name": "location_uuid",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/locations/": {
+            "get": {
+                "tags": [
+                    "Location"
+                ],
+                "operationId": "get_location_list_resource",
+                "responses": {
+                    "400": {
+                        "description": "raises LocationInvalidInput"
+                    },
+                    "200": {
+                        "description": "Locations",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedResponseApiLocationResourceSchema"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "locations:read"
+                        ]
+                    }
+                ],
+                "summary": "Retrieves all locations for your business",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "required": false,
+                        "description": "The number of results to be returned in each page. The value must be between 2 and 10,000. If not specified, the default value 1,000 will be used.",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1000,
+                            "minimum": 2,
+                            "maximum": 10000
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "start",
+                        "required": false,
+                        "description": "The ID of the last entity of the previous page, used for pagination to get the next page.",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Location"
+                ],
+                "operationId": "post_location_list_resource",
+                "responses": {
+                    "400": {
+                        "description": "raises LocationInvalidInput"
+                    },
+                    "200": {
+                        "description": "Location",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Location"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "locations:write"
+                        ]
+                    }
+                ],
+                "summary": "Create a new location",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiLocationCreate"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/developer/v1/receipts/": {
+            "get": {
+                "tags": [
+                    "Receipt"
+                ],
+                "operationId": "get_receipt_list_with_pagination",
+                "responses": {
+                    "400": {
+                        "description": "raises ReceiptInvalidInput"
+                    },
+                    "200": {
+                        "description": "Receipts",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedResponseApiReceiptResourceSchema"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "receipts:read"
+                        ]
+                    }
+                ],
+                "summary": "List all receipts of a business",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "required": false,
+                        "description": "The number of results to be returned in each page. The value must be between 2 and 10,000. If not specified, the default value 1,000 will be used.",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1000,
+                            "minimum": 2,
+                            "maximum": 10000
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "created_before",
+                        "required": false,
+                        "description": "Filter for receipts that were created before the specified date. Input need to be presented in ISO8601 format, e.g. 2020-12-02T00:00:00",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "from_date",
+                        "required": false,
+                        "description": "Filter for receipts related to transactions which occurred after the specified date. Input need to be presented in ISO8601 format, e.g. 2020-12-02T00:00:00",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "created_after",
+                        "required": false,
+                        "description": "Filter for receipts that were created after the specified date. Input need to be presented in ISO8601 format, e.g. 2020-12-02T00:00:00",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "start",
+                        "required": false,
+                        "description": "The ID of the last entity of the previous page, used for pagination to get the next page.",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "to_date",
+                        "required": false,
+                        "description": "Filter for receipts related to transactions which occurred before the specified date. Input need to be presented in ISO8601 format, e.g. 2020-12-02T00:00:00",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    }
+                ]
+            }
+        },
+        "/developer/v1/receipts/{receipt_id}": {
+            "get": {
+                "tags": [
+                    "Receipt"
+                ],
+                "operationId": "get_receipt_single_resource",
+                "responses": {
+                    "400": {
+                        "description": "raises ReceiptInvalidInput"
+                    },
+                    "200": {
+                        "description": "Receipt",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Receipt"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "receipts:read"
+                        ]
+                    }
+                ],
+                "summary": "Get details of single receipt"
+            },
+            "parameters": [
+                {
+                    "name": "receipt_id",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/reimbursements/{reimbursement_id}": {
+            "get": {
+                "tags": [
+                    "Reimbursement"
+                ],
+                "operationId": "get_reimbursement_resource",
+                "responses": {
+                    "200": {
+                        "description": "Reimbursement",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Reimbursement"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "reimbursements:read"
+                        ]
+                    }
+                ],
+                "summary": "Fetch a reimbursement by ID"
+            },
+            "parameters": [
+                {
+                    "name": "reimbursement_id",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/reimbursements/": {
+            "get": {
+                "tags": [
+                    "Reimbursement"
+                ],
+                "operationId": "get_reimbursement_list_with_pagination",
+                "responses": {
+                    "200": {
+                        "description": "Reimbursements",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedResponseApiReimbursementResourceSchema"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "reimbursements:read"
+                        ]
+                    }
+                ],
+                "summary": "List all the reimbursements",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "user_id",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "required": false,
+                        "description": "The number of results to be returned in each page. The value must be between 2 and 10,000. If not specified, the default value 1,000 will be used.",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1000,
+                            "minimum": 2,
+                            "maximum": 10000
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "start",
+                        "required": false,
+                        "description": "The ID of the last entity of the previous page, used for pagination to get the next page.",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "sync_ready",
+                        "required": false,
+                        "description": "Filter for reimbursements that are coded with accounting fields and ready to sync to ERP systems.",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "has_no_sync_commits",
+                        "required": false,
+                        "description": "Filter for reimbursements that have not been synced to ERP systems yet.",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ]
+            }
+        },
+        "/developer/v1/token/": {
+            "post": {
+                "tags": [
+                    "Token"
+                ],
+                "operationId": "post_token",
+                "responses": {
+                    "200": {
+                        "description": "Create token response"
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": []
+            }
+        },
+        "/developer/v1/token/pkce": {
+            "post": {
+                "tags": [
+                    "Token"
+                ],
+                "operationId": "post_pkce_token",
+                "responses": {
+                    "200": {
+                        "description": "Create token response for PKCE"
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": []
+            }
+        },
+        "/developer/v1/token/revoke": {
+            "post": {
+                "tags": [
+                    "Token"
+                ],
+                "operationId": "post_revoke_token",
+                "responses": {
+                    "200": {
+                        "description": "Revoked token successfully"
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": []
+            }
+        },
+        "/developer/v1/transactions/{transaction_id}": {
+            "get": {
+                "tags": [
+                    "Transaction"
+                ],
+                "operationId": "get_transaction_canonical_resource",
+                "responses": {
+                    "400": {
+                        "description": "raises TransactionInvalidInput"
+                    },
+                    "200": {
+                        "description": "Transaction",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Transaction"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "transactions:read"
+                        ]
+                    }
+                ],
+                "summary": "Fetch a single transaction by ID"
+            },
+            "parameters": [
+                {
+                    "name": "transaction_id",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/transactions/": {
+            "get": {
+                "tags": [
+                    "Transaction"
+                ],
+                "operationId": "get_transactions_canonical_list_with_pagination",
+                "responses": {
+                    "400": {
+                        "description": "raises TransactionInvalidInput"
+                    },
+                    "200": {
+                        "description": "Transactions",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedResponseApiTransactionCanonicalSchema"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "transactions:read"
+                        ]
+                    }
+                ],
+                "summary": "Retrieves all transactions for the business",
+                "description": "This endpoint supports filtering and ordering. Note that setting multiple ordering parameters is unsupported.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "min_amount",
+                        "required": false,
+                        "description": "Filter for transactions that have larger amount that the given amount. This is a U.S. Dollar denominated amount.",
+                        "schema": {
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "requires_memo",
+                        "required": false,
+                        "description": "Filters for transactions which require a memo, but do not have one. This can only be set to true.",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "manager_id",
+                        "required": false,
+                        "schema": {}
+                    },
+                    {
+                        "in": "query",
+                        "name": "max_amount",
+                        "required": false,
+                        "description": "Filter for transactions that have smaller amount that the given amount. This is a U.S. Dollar denominated amount.",
+                        "schema": {
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "to_date",
+                        "required": false,
+                        "description": "Filter for transactions that happens before the given date.",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "sk_category_id",
+                        "required": false,
+                        "description": "Filter by sk category.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "department_id",
+                        "required": false,
+                        "description": "Filter by department.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "card_id",
+                        "required": false,
+                        "description": "Filter by card.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "order_by_amount_desc",
+                        "required": false,
+                        "description": "Sort transactions by amount in descending order.",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "state",
+                        "required": false,
+                        "description": "Filter by transaction state.",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "ALL",
+                                "CLEARED",
+                                "COMPLETION",
+                                "DECLINED",
+                                "ERROR",
+                                "PENDING",
+                                "PENDING_INITIATION"
+                            ]
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "expense_policy_interaction_needs_review",
+                        "required": false,
+                        "description": "Filter for transactions that require expense policy review.",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "location_id",
+                        "required": false,
+                        "description": "Filter by location.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "order_by_amount_asc",
+                        "required": false,
+                        "description": "Sort transactions by amount in ascending order.",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "start",
+                        "required": false,
+                        "description": "The ID of the last entity of the previous page, used for pagination to get the next page.",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "order_by_date_desc",
+                        "required": false,
+                        "description": "Sort transactions by date in descending order.",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "has_no_sync_commits",
+                        "required": false,
+                        "description": "Filter for transactions that have not been synced to ERP systems yet.",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "user_id",
+                        "required": false,
+                        "description": "Filter by user.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "required": false,
+                        "description": "The number of results to be returned in each page. The value must be between 2 and 10,000. If not specified, the default value 1,000 will be used.",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1000,
+                            "minimum": 2,
+                            "maximum": 10000
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "from_date",
+                        "required": false,
+                        "description": "Filter for transactions that happens after the given date.",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "expense_policy_interaction_has_alert",
+                        "required": false,
+                        "description": "Filter for transactions that have expense policy alert.",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "merchant_id",
+                        "required": false,
+                        "description": "Filter by merchant.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "order_by_date_asc",
+                        "required": false,
+                        "description": "Sort transactions by date in ascending order.",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "sync_ready",
+                        "required": false,
+                        "description": "Filter for transactions that are coded with accounting fields and ready to sync to ERP systems.",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ]
+            }
+        },
+        "/developer/v1/users/{user_id}": {
+            "get": {
+                "tags": [
+                    "User"
+                ],
+                "operationId": "get_user_resource",
+                "responses": {
+                    "400": {
+                        "description": "raises UserInvalidInput"
+                    },
+                    "200": {
+                        "description": "User",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "users:read"
+                        ]
+                    }
+                ],
+                "summary": "Retrieve the information of the user with the matching user ID"
+            },
+            "patch": {
+                "tags": [
+                    "User"
+                ],
+                "operationId": "patch_user_resource",
+                "responses": {
+                    "400": {
+                        "description": "raises UserInvalidInput"
+                    },
+                    "204": {
+                        "description": "Update user"
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "users:write"
+                        ]
+                    }
+                ],
+                "summary": "Modify information about a user",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiUserUpdate"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "User"
+                ],
+                "operationId": "delete_user_resource",
+                "responses": {
+                    "204": {
+                        "description": "Delete user"
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "users:write"
+                        ]
+                    }
+                ],
+                "summary": "Suspends a user",
+                "description": "Note that this action does not delete the user's cards.\nCurrently this action is not reversible."
+            },
+            "parameters": [
+                {
+                    "name": "user_id",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/users/": {
+            "get": {
+                "tags": [
+                    "User"
+                ],
+                "operationId": "get_user_list_with_pagination",
+                "responses": {
+                    "400": {
+                        "description": "raises UserInvalidInput"
+                    },
+                    "200": {
+                        "description": "Users",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedResponseApiUserResourceSchema"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "users:read"
+                        ]
+                    }
+                ],
+                "summary": "Retrieve all users of the business",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "department_id",
+                        "required": false,
+                        "description": "filter by department",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "required": false,
+                        "description": "The number of results to be returned in each page. The value must be between 2 and 10,000. If not specified, the default value 1,000 will be used.",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1000,
+                            "minimum": 2,
+                            "maximum": 10000
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "location_id",
+                        "required": false,
+                        "description": "filter by location",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "start",
+                        "required": false,
+                        "description": "The ID of the last entity of the previous page, used for pagination to get the next page.",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "email",
+                        "required": false,
+                        "description": "filter by email",
+                        "schema": {
+                            "type": "string",
+                            "format": "email"
+                        }
+                    }
+                ]
+            }
+        },
+        "/developer/v1/users/deferred": {
+            "post": {
+                "tags": [
+                    "User"
+                ],
+                "operationId": "post_user_creation_deferred_task",
+                "responses": {
+                    "201": {
+                        "description": "Response with the ID of the async task. Task status can be checked via a GET call to .../deferred/status/<task_id>",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DeferredTaskUUID"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "users:write"
+                        ]
+                    }
+                ],
+                "summary": "Trigger an async task to create a new user",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiUserCreate"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/developer/v1/users/deferred/status/{task_uuid}": {
+            "get": {
+                "tags": [
+                    "User"
+                ],
+                "operationId": "get_user_deferred_task_resource",
+                "responses": {
+                    "200": {
+                        "description": "User deferred task status",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UserDeferredTask"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "users:write"
+                        ]
+                    }
+                ],
+                "summary": "Gets the status of a deferred task for users"
+            },
+            "parameters": [
+                {
+                    "name": "task_uuid",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/memos/{transaction_id}": {
+            "get": {
+                "tags": [
+                    "Memo"
+                ],
+                "operationId": "get_memo_single_resource",
+                "responses": {
+                    "404": {
+                        "description": "raises NotFound"
+                    },
+                    "400": {
+                        "description": "raises MemoInvalidInput"
+                    },
+                    "200": {
+                        "description": "Memo",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Memo"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "memos:read"
+                        ]
+                    }
+                ],
+                "summary": "Get the memo of a transaction"
+            },
+            "parameters": [
+                {
+                    "name": "transaction_id",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/memos/": {
+            "get": {
+                "tags": [
+                    "Memo"
+                ],
+                "operationId": "get_memo_list_with_pagination",
+                "responses": {
+                    "400": {
+                        "description": "raises MemoInvalidInput"
+                    },
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedResponseApiMemoResourceSchema"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "memos:read"
+                        ]
+                    }
+                ],
+                "summary": "Returns a list of memos that meets the criteria",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "user_id",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "department_id",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "required": false,
+                        "description": "The number of results to be returned in each page. The value must be between 2 and 10,000. If not specified, the default value 1,000 will be used.",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1000,
+                            "minimum": 2,
+                            "maximum": 10000
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "manager_id",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "from_date",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "location_id",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "card_id",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "start",
+                        "required": false,
+                        "description": "The ID of the last entity of the previous page, used for pagination to get the next page.",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "merchant_id",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "to_date",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    }
+                ]
+            }
+        },
+        "/developer/v1/merchants/": {
+            "get": {
+                "tags": [
+                    "Merchant"
+                ],
+                "operationId": "get_merchant_list_with_pagination",
+                "responses": {
+                    "400": {
+                        "description": "raises InvalidInput"
+                    },
+                    "200": {
+                        "description": "Merchants",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedResponseApiMerchantResourceSchema"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "merchants:read"
+                        ]
+                    }
+                ],
+                "summary": "List all the merchants",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "required": false,
+                        "description": "The number of results to be returned in each page. The value must be between 2 and 10,000. If not specified, the default value 1,000 will be used.",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1000,
+                            "minimum": 2,
+                            "maximum": 10000
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "start",
+                        "required": false,
+                        "description": "The ID of the last entity of the previous page, used for pagination to get the next page.",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "transaction_from_date",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "transaction_to_date",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    }
+                ]
+            }
+        },
+        "/developer/v1/leads/{sales_lead_id}": {
+            "get": {
+                "tags": [
+                    "SalesLead"
+                ],
+                "operationId": "get_sales_lead_resource",
+                "responses": {
+                    "404": {
+                        "description": "Sales lead not found"
+                    },
+                    "200": {
+                        "description": "Sales Lead",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Lead"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "leads:read"
+                        ]
+                    }
+                ],
+                "summary": "Fetch a sales lead by ID"
+            },
+            "parameters": [
+                {
+                    "name": "sales_lead_id",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/leads/": {
+            "post": {
+                "tags": [
+                    "SalesLead"
+                ],
+                "operationId": "post_sales_lead_creation",
+                "responses": {
+                    "400": {
+                        "description": "Invalid input"
+                    },
+                    "201": {
+                        "description": "Create a single sales lead"
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "leads:write"
+                        ]
+                    }
+                ],
+                "summary": "Create a sales lead",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiSalesLeadCreate"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/developer/v1/leads/{sales_lead_id}/upload_document": {
+            "post": {
+                "tags": [
+                    "SalesLead"
+                ],
+                "operationId": "post_sales_lead_document_upload",
+                "responses": {
+                    "400": {
+                        "description": "Invalid input"
+                    },
+                    "200": {
+                        "description": "Document uploaded",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Upload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "leads:write"
+                        ]
+                    }
+                ],
+                "summary": "Upload documents required by financing application process"
+            },
+            "parameters": [
+                {
+                    "name": "sales_lead_id",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/receipt-integrations/opt-out/{mailbox_opted_out_email_uuid}": {
+            "delete": {
+                "tags": [
+                    "Receipt Integrations"
+                ],
+                "operationId": "delete_receipt_integration_opted_out_emails_delete_resource",
+                "responses": {
+                    "200": {
+                        "description": "Success"
+                    }
+                },
+                "x-annotatedRequest": false,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "receipt_integrations:write"
+                        ]
+                    }
+                ],
+                "summary": "Remove an email from the Email-based receipt integration opt out list, opting it in"
+            },
+            "parameters": [
+                {
+                    "name": "mailbox_opted_out_email_uuid",
+                    "in": "path",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                    "style": "simple"
+                }
+            ]
+        },
+        "/developer/v1/receipt-integrations/opt-out": {
+            "get": {
+                "tags": [
+                    "Receipt Integrations"
+                ],
+                "operationId": "get_receipt_integration_opted_out_emails_list_resource",
+                "responses": {
+                    "200": {
+                        "description": "MailboxOptedOutEmail",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiReceiptIntegrationOptedOutEmailResource"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "receipt_integrations:read"
+                        ]
+                    }
+                ],
+                "summary": "List all emails that have been opted out of Email-based receipt integrations",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiReceiptIntegrationOptedOutEmailResource"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "Receipt Integrations"
+                ],
+                "operationId": "post_receipt_integration_opted_out_emails_list_resource",
+                "responses": {
+                    "201": {
+                        "description": "MailboxOptedOutEmail",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiReceiptIntegrationOptedOutEmailResource"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-annotatedRequest": true,
+                "x-annotatedResponse": true,
+                "security": [
+                    {
+                        "oauth2": [
+                            "receipt_integrations:write"
+                        ]
+                    }
+                ],
+                "summary": "Add a new email to be opted out of Email-based receipt integrations",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiReceiptIntegrationOptedOutEmailCreate"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "info": {
+        "title": "Ramp API",
+        "version": "v1",
+        "x-logo": {
+            "url": "https://assets-global.website-files.com/62278395da224f20d93b996a/62278395da224f5fbc3b9db1_ramp%20logo.svg",
+            "backgroundColor": "#ffffff"
+        }
+    },
+    "openapi": "3.0.2",
+    "components": {
+        "schemas": {
+            "NestedPage": {
+                "type": "object",
+                "properties": {
+                    "next": {
+                        "type": "string",
+                        "format": "uuid",
+                        "nullable": true
+                    }
+                },
+                "required": [
+                    "next"
+                ]
+            },
+            "Business": {
+                "type": "object",
+                "properties": {
+                    "website": {
+                        "type": "string"
+                    },
+                    "created_time": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "limit_locked": {
+                        "type": "boolean"
+                    },
+                    "phone": {
+                        "type": "string"
+                    },
+                    "business_name_on_card": {
+                        "type": "string"
+                    },
+                    "is_integrated_with_slack": {
+                        "type": "boolean"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "is_reimbursements_enabled": {
+                        "type": "boolean"
+                    },
+                    "initial_approved_limit": {
+                        "type": "integer"
+                    },
+                    "business_name_legal": {
+                        "type": "string"
+                    },
+                    "active": {
+                        "type": "boolean"
+                    },
+                    "enforce_sso": {
+                        "type": "boolean"
+                    },
+                    "billing_address": {
+                        "$ref": "#/components/schemas/CardShippingAddress"
+                    }
+                },
+                "example": {
+                    "active": true,
+                    "billing_address": {
+                        "address1": "123 Main St",
+                        "city": "New York City",
+                        "country": "US",
+                        "postal_code": "10003",
+                        "state": "NY"
+                    },
+                    "business_name_legal": "Sushi Luncheonette",
+                    "business_name_on_card": "Sushi Luncheonette",
+                    "created_time": "2022-08-20T16:54:29.968106+00:00",
+                    "enforce_sso": false,
+                    "id": "9abffcf0-dd7d-42f0-b806-ce0502ab6496",
+                    "initial_approved_limit": 2000000,
+                    "is_integrated_with_slack": false,
+                    "is_reimbursements_enabled": true,
+                    "limit_locked": false,
+                    "phone": "8014441234",
+                    "website": "www.ramp.com"
+                }
+            },
+            "BusinessBalance": {
+                "type": "object",
+                "properties": {
+                    "card_balance_including_pending": {
+                        "type": "number"
+                    },
+                    "balance_including_pending": {
+                        "type": "number"
+                    },
+                    "statement_balance": {
+                        "type": "number"
+                    },
+                    "available_flex_limit": {
+                        "type": "number"
+                    },
+                    "flex_balance": {
+                        "type": "number"
+                    },
+                    "max_balance": {
+                        "type": "number"
+                    },
+                    "flex_limit": {
+                        "type": "number"
+                    },
+                    "card_limit": {
+                        "type": "number"
+                    },
+                    "available_card_limit": {
+                        "type": "number"
+                    },
+                    "next_billing_date": {
+                        "type": "string"
+                    },
+                    "float_balance_excluding_pending": {
+                        "type": "number"
+                    },
+                    "card_balance_excluding_pending": {
+                        "type": "number"
+                    },
+                    "prev_billing_date": {
+                        "type": "string"
+                    },
+                    "global_limit": {
+                        "type": "number"
+                    }
+                },
+                "example": {
+                    "available_card_limit": 2000000,
+                    "available_flex_limit": 0,
+                    "balance_including_pending": 6271.22,
+                    "card_balance_excluding_pending": 4941.29,
+                    "card_balance_including_pending": 6271.22,
+                    "card_limit": 2000000,
+                    "flex_balance": 0,
+                    "flex_limit": 0,
+                    "float_balance_excluding_pending": 0,
+                    "global_limit": 2000000,
+                    "max_balance": 2000000,
+                    "next_billing_date": "09/17/2022",
+                    "prev_billing_date": "08/21/2022",
+                    "statement_balance": 4941.29
+                }
+            },
+            "CardShippingAddress": {
+                "type": "object",
+                "properties": {
+                    "city": {
+                        "type": "string"
+                    },
+                    "state": {
+                        "type": "string"
+                    },
+                    "phone": {
+                        "type": "string"
+                    },
+                    "address2": {
+                        "type": "string"
+                    },
+                    "postal_code": {
+                        "type": "string"
+                    },
+                    "country": {
+                        "type": "string"
+                    },
+                    "last_name": {
+                        "type": "string"
+                    },
+                    "address1": {
+                        "type": "string"
+                    },
+                    "first_name": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "address1",
+                    "city",
+                    "country",
+                    "first_name",
+                    "last_name",
+                    "postal_code"
+                ]
+            },
+            "CardShipping": {
+                "type": "object",
+                "properties": {
+                    "return_address": {
+                        "$ref": "#/components/schemas/CardShippingAddress"
+                    },
+                    "method": {
+                        "type": "string"
+                    },
+                    "recipient_address": {
+                        "$ref": "#/components/schemas/CardShippingAddress"
+                    },
+                    "recipient_address_verification_state": {
+                        "type": "string",
+                        "enum": [
+                            "NOT_VERIFIED",
+                            "OVERRIDEN",
+                            "VERIFIED"
+                        ]
+                    }
+                }
+            },
+            "CardPersonalizationNameLine": {
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "string"
+                    }
+                }
+            },
+            "CardPersonalizationText": {
+                "type": "object",
+                "properties": {
+                    "name_line_2": {
+                        "$ref": "#/components/schemas/CardPersonalizationNameLine"
+                    },
+                    "name_line_1": {
+                        "$ref": "#/components/schemas/CardPersonalizationNameLine"
+                    }
+                }
+            },
+            "CardPersonalization": {
+                "type": "object",
+                "properties": {
+                    "text": {
+                        "$ref": "#/components/schemas/CardPersonalizationText"
+                    }
+                }
+            },
+            "ApiCardFulfillment": {
+                "type": "object",
+                "properties": {
+                    "shipping_tracking_url": {
+                        "type": "string",
+                        "description": "Tracking url"
+                    },
+                    "shipping_eta": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Estimated arrival time, presented in ISO8601 format"
+                    },
+                    "fulfillment_status": {
+                        "description": "Fulfillment status of the card",
+                        "type": "string",
+                        "enum": [
+                            "DELIVERED",
+                            "DIGITALLY_PRESENTED",
+                            "ISSUED",
+                            "ORDERED",
+                            "REJECTED",
+                            "SHIPPED"
+                        ]
+                    },
+                    "shipping": {
+                        "$ref": "#/components/schemas/CardShipping"
+                    },
+                    "card_personalization": {
+                        "$ref": "#/components/schemas/CardPersonalization"
+                    },
+                    "shipping_date": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date on which the card is shipped out, presented in ISO8601 format"
+                    }
+                }
+            },
+            "ApiCardSpendingRestrictionsDump": {
+                "type": "object",
+                "properties": {
+                    "categories": {
+                        "type": "array",
+                        "description": "List of Ramp Category Codes this card is restricted to.",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "auto_lock_date": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date to automatically lock the card."
+                    },
+                    "amount": {
+                        "type": "number",
+                        "description": "Amount limit total per interval."
+                    },
+                    "suspended": {
+                        "type": "boolean"
+                    },
+                    "transaction_amount_limit": {
+                        "type": "number",
+                        "description": "Max amount limit per transaction."
+                    },
+                    "interval": {
+                        "description": "Time interval to apply limit to.",
+                        "type": "string",
+                        "enum": [
+                            "ANNUAL",
+                            "DAILY",
+                            "MONTHLY",
+                            "QUARTERLY",
+                            "TERTIARY",
+                            "TOTAL",
+                            "WEEKLY",
+                            "YEARLY"
+                        ]
+                    },
+                    "blocked_categories": {
+                        "type": "array",
+                        "description": "List of Ramp Category Codes blocked for this card.",
+                        "items": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            },
+            "Card": {
+                "type": "object",
+                "properties": {
+                    "fulfillment": {
+                        "description": "Fulfillment details of a physical Ramp card.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ApiCardFulfillment"
+                            }
+                        ]
+                    },
+                    "state": {
+                        "description": "State of the card",
+                        "type": "string",
+                        "enum": [
+                            "ACTIVE",
+                            "SUSPENDED",
+                            "TERMINATED",
+                            "UNACTIVATED"
+                        ]
+                    },
+                    "cardholder_name": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Card holder's full name."
+                    },
+                    "card_program_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the card program."
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the card."
+                    },
+                    "cardholder_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the card holder."
+                    },
+                    "has_program_overridden": {
+                        "type": "boolean",
+                        "description": "Whether the card has overridden the default settings from its card program."
+                    },
+                    "is_physical": {
+                        "type": "boolean"
+                    },
+                    "spending_restrictions": {
+                        "description": "Specifies the spend restrictions on a Ramp card.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ApiCardSpendingRestrictionsDump"
+                            }
+                        ]
+                    },
+                    "last_four": {
+                        "type": "string"
+                    },
+                    "display_name": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "last_four"
+                ],
+                "example": {
+                    "card_program_id": null,
+                    "cardholder_id": "3a5b1f62-988f-4190-bf31-b7ae87c5df42",
+                    "cardholder_name": "Julie Phillip",
+                    "display_name": "T&E",
+                    "fulfillment": {
+                        "fulfillment_status": "ISSUED",
+                        "shipping": {
+                            "recipient_address": {
+                                "address1": "123 Main St",
+                                "city": "New York City",
+                                "country": "US",
+                                "first_name": "Julie",
+                                "last_name": "Phillip",
+                                "postal_code": "10003",
+                                "state": "NY"
+                            }
+                        },
+                        "shipping_date": null,
+                        "shipping_eta": null,
+                        "shipping_tracking_url": null
+                    },
+                    "has_program_overridden": false,
+                    "id": "d8135cfe-0396-4b2d-b2cf-ad809fb04731",
+                    "is_physical": false,
+                    "last_four": "3751",
+                    "state": "ACTIVE",
+                    "spending_restrictions": {
+                        "amount": 5000,
+                        "auto_lock_date": null,
+                        "blocked_categories": [],
+                        "categories": [],
+                        "interval": "MONTHLY",
+                        "suspended": false,
+                        "transaction_amount_limit": null
+                    }
+                }
+            },
+            "ApiCardAccountingRulesData": {
+                "type": "object",
+                "properties": {
+                    "accounting_provider_access_uuid": {
+                        "type": "string"
+                    },
+                    "tracking_category_id": {
+                        "type": "integer"
+                    },
+                    "tracking_category_option_id": {
+                        "type": "integer"
+                    },
+                    "tracking_category_option_remote_name": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "tracking_category_id",
+                    "tracking_category_option_id",
+                    "tracking_category_option_remote_name"
+                ]
+            },
+            "ApiCardSpendingRestrictionsUpdate": {
+                "type": "object",
+                "properties": {
+                    "categories": {
+                        "type": "array",
+                        "description": "List of Ramp Category Codes this card is restricted to.",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "amount": {
+                        "type": "number",
+                        "minimum": 0,
+                        "description": "Amount limit total per interval."
+                    },
+                    "policy_id": {
+                        "type": "string"
+                    },
+                    "vendor_whitelist": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    "blocked_mcc_codes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "categories_blacklist": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "card_accounting_rules": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ApiCardAccountingRulesData"
+                        }
+                    },
+                    "vendor_blacklist": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    "lock_date": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true,
+                        "description": "Date to automatically lock the card. If lock date has passed, set to a future date or to null to unlock the card."
+                    },
+                    "categories_whitelist": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "transaction_amount_limit": {
+                        "type": "number",
+                        "minimum": 0,
+                        "description": "Max amount limit per transaction."
+                    },
+                    "interval": {
+                        "description": "Time interval to apply limit to.",
+                        "type": "string",
+                        "enum": [
+                            "ANNUAL",
+                            "DAILY",
+                            "MONTHLY",
+                            "QUARTERLY",
+                            "TERTIARY",
+                            "TOTAL",
+                            "WEEKLY",
+                            "YEARLY"
+                        ]
+                    }
+                }
+            },
+            "ApiCardUpdate": {
+                "type": "object",
+                "properties": {
+                    "card_program_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "nullable": true,
+                        "description": "Specify a card program to link with.\n            This will override the card's spending restrictions with those of the card program.\n            Pass card_program_id = None to detach the card's current card program.\n\n            If the card_program_id field is specified, then the card program's changes will override any other changes.\n            For example, if both spending_restrictions and card_program_id are passed, then the new spending restrictions\n            will match those of the card program (not the passed spending restrictions).\n            "
+                    },
+                    "display_name": {
+                        "type": "string",
+                        "description": "Cosmetic display name of the card."
+                    },
+                    "has_notifications_enabled": {
+                        "type": "boolean",
+                        "description": "Flag to set to enable or disable notifications."
+                    },
+                    "spending_restrictions": {
+                        "description": "Modify spending restrictions. Only the fields to be modified need to be passed (so fields that will stay the same do not have to be passed).",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ApiCardSpendingRestrictionsUpdate"
+                            }
+                        ]
+                    }
+                },
+                "example": {
+                    "display_name": "WFH Spending Card",
+                    "has_notifications_enabled": true,
+                    "spending_restrictions": {
+                        "amount": 500,
+                        "interval": "DAILY"
+                    }
+                }
+            },
+            "DeferredTaskUUID": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "ID of the deferred task."
+                    }
+                },
+                "required": [
+                    "id"
+                ]
+            },
+            "ApiCardDeferredUpdate": {
+                "type": "object",
+                "properties": {
+                    "idempotency_key": {
+                        "type": "string",
+                        "description": "An idempotency key is a unique value generated by the client which the server uses to recognize subsequent retries of the same request. To avoid collisions, we encourage clients to use random generated UUIDs."
+                    }
+                },
+                "required": [
+                    "idempotency_key"
+                ]
+            },
+            "DeveloperAPINestedPage": {
+                "type": "object",
+                "properties": {
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "the query to get to the next page; it is in the format of <BASE_URL>?<new_params>"
+                    }
+                },
+                "required": [
+                    "next"
+                ],
+                "example": {
+                    "next": "https://api.ramp.com/developer/v1/<resources>?<new_params>"
+                }
+            },
+            "PaginatedResponseApiCardResourceSchema": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "$ref": "#/components/schemas/DeveloperAPINestedPage"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Card"
+                        }
+                    }
+                },
+                "required": [
+                    "data",
+                    "page"
+                ],
+                "example": {
+                    "page": {
+                        "next": "https://api.ramp.com/developer/v1/<resources>?<new_params>"
+                    },
+                    "data": [
+                        {
+                            "card_program_id": null,
+                            "cardholder_id": "3a5b1f62-988f-4190-bf31-b7ae87c5df42",
+                            "cardholder_name": "Julie Phillip",
+                            "display_name": "T&E",
+                            "fulfillment": {
+                                "fulfillment_status": "ISSUED",
+                                "shipping": {
+                                    "recipient_address": {
+                                        "address1": "123 Main St",
+                                        "city": "New York City",
+                                        "country": "US",
+                                        "first_name": "Julie",
+                                        "last_name": "Phillip",
+                                        "postal_code": "10003",
+                                        "state": "NY"
+                                    }
+                                },
+                                "shipping_date": null,
+                                "shipping_eta": null,
+                                "shipping_tracking_url": null
+                            },
+                            "has_program_overridden": false,
+                            "id": "d8135cfe-0396-4b2d-b2cf-ad809fb04731",
+                            "is_physical": false,
+                            "last_four": "3751",
+                            "state": "ACTIVE",
+                            "spending_restrictions": {
+                                "amount": 5000,
+                                "auto_lock_date": null,
+                                "blocked_categories": [],
+                                "categories": [],
+                                "interval": "MONTHLY",
+                                "suspended": false,
+                                "transaction_amount_limit": null
+                            }
+                        }
+                    ]
+                }
+            },
+            "CardFulfillment": {
+                "type": "object",
+                "properties": {
+                    "shipping": {
+                        "$ref": "#/components/schemas/CardShipping"
+                    },
+                    "card_personalization": {
+                        "$ref": "#/components/schemas/CardPersonalization"
+                    }
+                }
+            },
+            "ApiCardSpendingRestrictionsLoad": {
+                "type": "object",
+                "properties": {
+                    "categories": {
+                        "type": "array",
+                        "description": "List of Ramp Category Codes this card is restricted to.",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "amount": {
+                        "type": "number",
+                        "minimum": 0,
+                        "description": "Amount limit total per interval."
+                    },
+                    "policy_id": {
+                        "type": "string"
+                    },
+                    "vendor_whitelist": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    "blocked_mcc_codes": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "categories_blacklist": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "card_accounting_rules": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ApiCardAccountingRulesData"
+                        }
+                    },
+                    "vendor_blacklist": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    "lock_date": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date to automatically lock the card. If lock date has passed, set to a future date or to null to unlock the card."
+                    },
+                    "categories_whitelist": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "transaction_amount_limit": {
+                        "type": "number",
+                        "minimum": 0,
+                        "description": "Max amount limit per transaction."
+                    },
+                    "interval": {
+                        "description": "Time interval to apply limit to.",
+                        "type": "string",
+                        "enum": [
+                            "ANNUAL",
+                            "DAILY",
+                            "MONTHLY",
+                            "QUARTERLY",
+                            "TERTIARY",
+                            "TOTAL",
+                            "WEEKLY",
+                            "YEARLY"
+                        ]
+                    }
+                },
+                "required": [
+                    "amount",
+                    "interval"
+                ]
+            },
+            "ApiCardRequest": {
+                "type": "object",
+                "properties": {
+                    "fulfillment": {
+                        "description": "Details for shipping physical cards.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/CardFulfillment"
+                            }
+                        ]
+                    },
+                    "user_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the card owner."
+                    },
+                    "card_program_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Alternative method to create a card using a card program. If this value is given, no other attributes (other than idempotency_key) may be given."
+                    },
+                    "idempotency_key": {
+                        "type": "string",
+                        "description": "An idempotency key is a unique value generated by the client which the server uses to recognize subsequent retries of the same request. To avoid collisions, we encourage clients to use random generated UUIDs."
+                    },
+                    "is_physical": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Set to true to create a physical card"
+                    },
+                    "spending_restrictions": {
+                        "description": "Specifies the spend restrictions on a Ramp card.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ApiCardSpendingRestrictionsLoad"
+                            }
+                        ]
+                    },
+                    "is_temporary": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Set to true to create a temporary card"
+                    },
+                    "display_name": {
+                        "type": "string",
+                        "description": "Cosmetic display name of the card."
+                    }
+                },
+                "required": [
+                    "idempotency_key",
+                    "user_id"
+                ],
+                "example": {
+                    "idempotency_key": "3a5b1f62-988f-4190-bf31-b7ae87c5df42",
+                    "user_id": "d8135cfe-0396-4b2d-b2cf-ad809fb04731",
+                    "display_name": "T&E",
+                    "fulfillment": {
+                        "fulfillment_status": "ISSUED",
+                        "shipping": {
+                            "recipient_address": {
+                                "address1": "123 Main St",
+                                "city": "New York City",
+                                "country": "US",
+                                "first_name": "Julie",
+                                "last_name": "Phillip",
+                                "postal_code": "10003",
+                                "state": "NY"
+                            }
+                        },
+                        "shipping_date": null,
+                        "shipping_eta": null,
+                        "shipping_tracking_url": null
+                    },
+                    "is_physical": true,
+                    "spending_restrictions": {
+                        "amount": 5000,
+                        "auto_lock_date": null,
+                        "blocked_categories": [],
+                        "categories": [],
+                        "interval": "MONTHLY",
+                        "suspended": false,
+                        "transaction_amount_limit": null
+                    }
+                }
+            },
+            "ApiCardDeferredTaskData": {
+                "type": "object",
+                "properties": {
+                    "card_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the subject card in the deferred task."
+                    },
+                    "error": {
+                        "type": "string",
+                        "description": "An error message if the deferred task fails."
+                    }
+                }
+            },
+            "CardDeferredTask": {
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "description": "Status of the deferred task. It could be one of the following values: STARTED, IN_PROGRESS, ERROR, SUCCESS"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the deferred task."
+                    },
+                    "data": {
+                        "description": "Detailed data of the deferred task.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ApiCardDeferredTaskData"
+                            }
+                        ]
+                    }
+                },
+                "example": {
+                    "id": "2d68eb67-f6eb-4284-8683-7d530c77a5a6",
+                    "data": {
+                        "card_id": "f4efe11c-221f-4b49-a1e4-33eaf96a49ee"
+                    },
+                    "status": "SUCCESS"
+                }
+            },
+            "ApiCardProgramSpendingRestrictions": {
+                "type": "object",
+                "properties": {
+                    "categories": {
+                        "type": "array",
+                        "description": "List of Ramp Category Codes this card is restricted to.",
+                        "items": {
+                            "type": "integer"
+                        }
+                    },
+                    "amount": {
+                        "type": "number",
+                        "description": "Amount limit total per interval."
+                    },
+                    "lock_date": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date to automatically lock the card."
+                    },
+                    "transaction_amount_limit": {
+                        "type": "number",
+                        "description": "Max amount limit per transaction."
+                    },
+                    "interval": {
+                        "description": "Time interval to apply limit to.",
+                        "type": "string",
+                        "enum": [
+                            "ANNUAL",
+                            "DAILY",
+                            "MONTHLY",
+                            "QUARTERLY",
+                            "TERTIARY",
+                            "TOTAL",
+                            "WEEKLY",
+                            "YEARLY"
+                        ]
+                    }
+                }
+            },
+            "ApiCardProgramResource": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifer of the card program."
+                    },
+                    "is_default": {
+                        "type": "boolean",
+                        "description": "Whether this card program is used as default card program."
+                    },
+                    "is_physical": {
+                        "type": "boolean",
+                        "description": "Whether this card program is used for physical cards."
+                    },
+                    "spending_restrictions": {
+                        "description": "Spending restrictions associated with the card program.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ApiCardProgramSpendingRestrictions"
+                            }
+                        ]
+                    },
+                    "display_name": {
+                        "type": "string",
+                        "description": "Display name of the card program."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Card program description."
+                    },
+                    "icon": {
+                        "type": "string",
+                        "enum": [
+                            "AdvertisingIcon",
+                            "CardIcon",
+                            "EducationStipendIcon",
+                            "LunchOrderingIcon",
+                            "OnboardingIcon",
+                            "PerDiemCardIcon",
+                            "SaasSubscriptionIcon",
+                            "SoftwareTrialIcon",
+                            "TravelExpensesIcon",
+                            "WellnessIcon"
+                        ]
+                    }
+                },
+                "example": {
+                    "description": "Offer a yearly stipend for conferences and courses.",
+                    "display_name": "Education Stipend",
+                    "icon": "EducationStipendIcon",
+                    "id": "97ad0c67-c318-4591-9b0e-202ecceb8016",
+                    "is_default": false,
+                    "is_physical": false,
+                    "spending_restrictions": {
+                        "amount": 750,
+                        "categories": [
+                            33
+                        ],
+                        "interval": "YEARLY",
+                        "lock_date": "2024-08-20T00:00:00+00:00",
+                        "transaction_amount_limit": 200
+                    }
+                }
+            },
+            "PaginatedResponseApiCardProgramResourceSchema": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "$ref": "#/components/schemas/DeveloperAPINestedPage"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ApiCardProgramResource"
+                        }
+                    }
+                },
+                "required": [
+                    "data",
+                    "page"
+                ],
+                "example": {
+                    "page": {
+                        "next": "https://api.ramp.com/developer/v1/<resources>?<new_params>"
+                    },
+                    "data": [
+                        {
+                            "description": "Offer a yearly stipend for conferences and courses.",
+                            "display_name": "Education Stipend",
+                            "icon": "EducationStipendIcon",
+                            "id": "97ad0c67-c318-4591-9b0e-202ecceb8016",
+                            "is_default": false,
+                            "is_physical": false,
+                            "spending_restrictions": {
+                                "amount": 750,
+                                "categories": [
+                                    33
+                                ],
+                                "interval": "YEARLY",
+                                "lock_date": "2024-08-20T00:00:00+00:00",
+                                "transaction_amount_limit": 200
+                            }
+                        }
+                    ]
+                }
+            },
+            "ApiCardProgramCreate": {
+                "type": "object",
+                "properties": {
+                    "acting_user_id": {
+                        "type": "integer"
+                    },
+                    "business_id": {
+                        "type": "integer"
+                    },
+                    "is_default": {
+                        "type": "boolean",
+                        "description": "Whether this card program is used as default card program."
+                    },
+                    "is_physical": {
+                        "type": "boolean",
+                        "description": "Whether this card program is used for physical cards."
+                    },
+                    "spending_restrictions": {
+                        "description": "Spending restrictions associated with the card program.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ApiCardSpendingRestrictionsLoad"
+                            }
+                        ]
+                    },
+                    "policy_id": {
+                        "type": "integer"
+                    },
+                    "display_name": {
+                        "type": "string",
+                        "description": "Display name of the card program."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Description of the card program."
+                    },
+                    "icon": {
+                        "type": "string",
+                        "enum": [
+                            "AdvertisingIcon",
+                            "CardIcon",
+                            "EducationStipendIcon",
+                            "LunchOrderingIcon",
+                            "OnboardingIcon",
+                            "PerDiemCardIcon",
+                            "SaasSubscriptionIcon",
+                            "SoftwareTrialIcon",
+                            "TravelExpensesIcon",
+                            "WellnessIcon"
+                        ]
+                    }
+                },
+                "required": [
+                    "acting_user_id",
+                    "business_id",
+                    "description",
+                    "display_name",
+                    "is_default",
+                    "is_physical",
+                    "policy_id",
+                    "spending_restrictions"
+                ],
+                "example": {
+                    "description": "Offer a yearly stipend for conferences and courses.",
+                    "display_name": "Education Stipend",
+                    "icon": "EducationStipendIcon",
+                    "is_default": false,
+                    "is_physical": false,
+                    "spending_restrictions": {
+                        "amount": 750,
+                        "categories": [
+                            33
+                        ],
+                        "interval": "YEARLY",
+                        "lock_date": "2024-08-20T00:00:00+00:00"
+                    }
+                }
+            },
+            "CustomIdProvider": {
+                "type": "object",
+                "properties": {
+                    "custom_id_provider": {
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                }
+            },
+            "ApiCustomIdProviderTokenCreate": {
+                "type": "object",
+                "properties": {
+                    "custom_id_provider": {
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                },
+                "required": [
+                    "custom_id_provider"
+                ]
+            },
+            "RampId": {
+                "type": "object",
+                "properties": {
+                    "ramp_id": {
+                        "type": "string"
+                    }
+                }
+            },
+            "CustomId": {
+                "type": "object",
+                "properties": {
+                    "custom_id": {
+                        "type": "string"
+                    }
+                }
+            },
+            "ApiCustomIdMapping": {
+                "type": "object",
+                "properties": {
+                    "custom_id": {
+                        "type": "string",
+                        "enum": [
+                            "a",
+                            "b",
+                            "c",
+                            "d",
+                            "e",
+                            "f",
+                            "g",
+                            "h",
+                            "i",
+                            "j",
+                            "k",
+                            "l",
+                            "m",
+                            "n",
+                            "o",
+                            "p",
+                            "q",
+                            "r",
+                            "s",
+                            "t",
+                            "u",
+                            "v",
+                            "w",
+                            "x",
+                            "y",
+                            "z",
+                            "0",
+                            "1",
+                            "2",
+                            "3",
+                            "4",
+                            "5",
+                            "6",
+                            "7",
+                            "8",
+                            "9",
+                            "-"
+                        ],
+                        "maxLength": 64
+                    },
+                    "ramp_id": {
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                },
+                "required": [
+                    "custom_id",
+                    "ramp_id"
+                ]
+            },
+            "Department": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "example": {
+                    "id": "c16b6ee1-2f5d-45e9-9fb4-c1c541a9ea70",
+                    "name": "Bookkeeping"
+                }
+            },
+            "ApiDepartmentUpdate": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ]
+            },
+            "PaginatedResponseApiDepartmentResourceSchema": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "$ref": "#/components/schemas/DeveloperAPINestedPage"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Department"
+                        }
+                    }
+                },
+                "required": [
+                    "data",
+                    "page"
+                ],
+                "example": {
+                    "page": {
+                        "next": "https://api.ramp.com/developer/v1/<resources>?<new_params>"
+                    },
+                    "data": [
+                        {
+                            "id": "c16b6ee1-2f5d-45e9-9fb4-c1c541a9ea70",
+                            "name": "Bookkeeping"
+                        }
+                    ]
+                }
+            },
+            "ApiDepartmentCreate": {
+                "type": "object",
+                "properties": {
+                    "business_id": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "business_id",
+                    "name"
+                ]
+            },
+            "Location": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "example": {
+                    "id": "f4efe11c-221f-4b49-a1e4-33eaf96a49ee",
+                    "name": "New York City"
+                }
+            },
+            "ApiLocationUpdate": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "PaginatedResponseApiLocationResourceSchema": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "$ref": "#/components/schemas/DeveloperAPINestedPage"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Location"
+                        }
+                    }
+                },
+                "required": [
+                    "data",
+                    "page"
+                ],
+                "example": {
+                    "page": {
+                        "next": "https://api.ramp.com/developer/v1/<resources>?<new_params>"
+                    },
+                    "data": [
+                        {
+                            "id": "f4efe11c-221f-4b49-a1e4-33eaf96a49ee",
+                            "name": "New York City"
+                        }
+                    ]
+                }
+            },
+            "ApiLocationCreate": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "business_id": {
+                        "type": "integer"
+                    }
+                },
+                "required": [
+                    "business_id",
+                    "name"
+                ]
+            },
+            "Receipt": {
+                "type": "object",
+                "properties": {
+                    "user_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the person who made the transaction."
+                    },
+                    "transaction_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the associated transaction."
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the receipt."
+                    },
+                    "receipt_url": {
+                        "type": "string",
+                        "description": "Pre-signed url to download receipt image."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "example": {
+                    "created_at": "2022-08-20T20:33:46.920991",
+                    "id": "0a0ed428-0250-4993-96ad-94cd77bc86b6",
+                    "receipt_url": "https://receipts.ramp.com/sales_demo_instance/amazon_business_receipt.png?Expires=1661130671",
+                    "transaction_id": "065916d9-7bdf-4aae-a46a-9b82225f2a20",
+                    "user_id": "ea0d554a-78bb-4402-a3e9-2d4bc138502f"
+                }
+            },
+            "PaginatedResponseApiReceiptResourceSchema": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "$ref": "#/components/schemas/DeveloperAPINestedPage"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Receipt"
+                        }
+                    }
+                },
+                "required": [
+                    "data",
+                    "page"
+                ],
+                "example": {
+                    "page": {
+                        "next": "https://api.ramp.com/developer/v1/<resources>?<new_params>"
+                    },
+                    "data": [
+                        {
+                            "created_at": "2022-08-20T20:33:46.920991",
+                            "id": "0a0ed428-0250-4993-96ad-94cd77bc86b6",
+                            "receipt_url": "https://receipts.ramp.com/sales_demo_instance/amazon_business_receipt.png?Expires=1661130671",
+                            "transaction_id": "065916d9-7bdf-4aae-a46a-9b82225f2a20",
+                            "user_id": "ea0d554a-78bb-4402-a3e9-2d4bc138502f"
+                        }
+                    ]
+                }
+            },
+            "ApiReimbursementAccountingFieldSelection": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "ID that uniquely identifies an accounting field option within Ramp"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "name of accounting field option"
+                    },
+                    "external_id": {
+                        "type": "string",
+                        "description": "external id of accounting field option; It should uniquely identify an accounting field option on the client end."
+                    },
+                    "type": {
+                        "description": "Accounting field type",
+                        "type": "string",
+                        "enum": [
+                            "AMORTIZATION_TEMPLATE",
+                            "BILLABLE",
+                            "CUSTOMERS_JOBS",
+                            "GL_ACCOUNT",
+                            "INVENTORY_ITEM",
+                            "MERCHANT",
+                            "OTHER",
+                            "SUBSIDIARY",
+                            "TAX_CODE"
+                        ]
+                    }
+                }
+            },
+            "CurrencyAmount": {
+                "type": "object",
+                "properties": {
+                    "currency_code": {
+                        "type": "string",
+                        "default": "USD",
+                        "description": "The type of currency, in ISO 4217 format. e.g. USD for US dollars"
+                    },
+                    "amount": {
+                        "type": "integer",
+                        "description": "the amount of money represented in the smallest denomination of the currency. For example, when the currency is USD, then the amount is expressed in cents."
+                    }
+                },
+                "required": [
+                    "amount"
+                ]
+            },
+            "ApiReimbursementLineItem": {
+                "type": "object",
+                "properties": {
+                    "accounting_field_selections": {
+                        "description": "List of accounting field options related to the line item.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ApiReimbursementAccountingFieldSelection"
+                        }
+                    },
+                    "amount": {
+                        "description": "Amount of the line item",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/CurrencyAmount"
+                            }
+                        ]
+                    }
+                }
+            },
+            "Reimbursement": {
+                "type": "object",
+                "properties": {
+                    "accounting_field_selections": {
+                        "description": "List of accounting fields related to the reimbursement.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ApiReimbursementAccountingFieldSelection"
+                        }
+                    },
+                    "user_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the person who made the reimbursement."
+                    },
+                    "amount": {
+                        "type": "number",
+                        "description": "The amount that the payor pays."
+                    },
+                    "line_items": {
+                        "description": "List of line items related to the reimbursement.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ApiReimbursementLineItem"
+                        }
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the reimbursement."
+                    },
+                    "receipts": {
+                        "readOnly": true,
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    "currency": {
+                        "type": "string",
+                        "description": "The currency that the payor pays with."
+                    },
+                    "transaction_date": {
+                        "type": "string",
+                        "format": "date"
+                    },
+                    "merchant": {
+                        "type": "string"
+                    },
+                    "original_reimbursement_amount": {
+                        "description": "Original reimbursement amount before the currency conversion.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/CurrencyAmount"
+                            }
+                        ]
+                    },
+                    "direction": {
+                        "description": "The direction of the reimbursement. It could be either BUSINESS_TO_USER or USER_TO_BUSINESS.",
+                        "type": "string",
+                        "enum": [
+                            "BUSINESS_TO_USER",
+                            "USER_TO_BUSINESS"
+                        ]
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Time at which the reimbursement is created. Presented in ISO8601 format."
+                    }
+                },
+                "example": {
+                    "amount": 484.46,
+                    "created_at": "2022-08-20T18:56:52.197588",
+                    "currency": "USD",
+                    "direction": "BUSINESS_TO_USER",
+                    "id": "d47ba06e-14ac-4a7b-89b4-4775412ba545",
+                    "merchant": "Delta Airlines",
+                    "receipts": [],
+                    "transaction_date": "2022-08-19",
+                    "user_id": "7979392e-8d41-4f97-815b-ccd7584802bf",
+                    "original_reimbursement_amount": {
+                        "amount": 48446,
+                        "currency_code": "USD"
+                    },
+                    "accounting_field_selections": [
+                        {
+                            "id": "07b4ce4d-2750-412e-aef4-6b7815f1411c",
+                            "external_id": "Category",
+                            "name": "Category",
+                            "type": "GL_ACCOUNT"
+                        }
+                    ],
+                    "line_items": [
+                        {
+                            "amount": {
+                                "amount": 5000,
+                                "currency_code": "USD"
+                            },
+                            "accounting_field_selections": [
+                                {
+                                    "id": "07b4ce4d-2750-412e-aef4-6b7815f1411a",
+                                    "type": "Subsidiary",
+                                    "external_id": "426",
+                                    "name": "Ramp BV"
+                                }
+                            ]
+                        },
+                        {
+                            "amount": {
+                                "amount": 43446,
+                                "currency_code": "USD"
+                            },
+                            "accounting_field_selections": [
+                                {
+                                    "id": "07b4ce4d-2750-412e-aef4-6b7815f1411b",
+                                    "type": "Subsidiary",
+                                    "external_id": "425",
+                                    "name": "Ramp LP"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "PaginatedResponseApiReimbursementResourceSchema": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "$ref": "#/components/schemas/DeveloperAPINestedPage"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Reimbursement"
+                        }
+                    }
+                },
+                "required": [
+                    "data",
+                    "page"
+                ],
+                "example": {
+                    "page": {
+                        "next": "https://api.ramp.com/developer/v1/<resources>?<new_params>"
+                    },
+                    "data": [
+                        {
+                            "amount": 484.46,
+                            "created_at": "2022-08-20T18:56:52.197588",
+                            "currency": "USD",
+                            "direction": "BUSINESS_TO_USER",
+                            "id": "d47ba06e-14ac-4a7b-89b4-4775412ba545",
+                            "merchant": "Delta Airlines",
+                            "receipts": [],
+                            "transaction_date": "2022-08-19",
+                            "user_id": "7979392e-8d41-4f97-815b-ccd7584802bf",
+                            "original_reimbursement_amount": {
+                                "amount": 48446,
+                                "currency_code": "USD"
+                            },
+                            "accounting_field_selections": [
+                                {
+                                    "id": "07b4ce4d-2750-412e-aef4-6b7815f1411c",
+                                    "external_id": "Category",
+                                    "name": "Category",
+                                    "type": "GL_ACCOUNT"
+                                }
+                            ],
+                            "line_items": [
+                                {
+                                    "amount": {
+                                        "amount": 5000,
+                                        "currency_code": "USD"
+                                    },
+                                    "accounting_field_selections": [
+                                        {
+                                            "id": "07b4ce4d-2750-412e-aef4-6b7815f1411a",
+                                            "type": "Subsidiary",
+                                            "external_id": "426",
+                                            "name": "Ramp BV"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "amount": {
+                                        "amount": 43446,
+                                        "currency_code": "USD"
+                                    },
+                                    "accounting_field_selections": [
+                                        {
+                                            "id": "07b4ce4d-2750-412e-aef4-6b7815f1411b",
+                                            "type": "Subsidiary",
+                                            "external_id": "425",
+                                            "name": "Ramp LP"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            "ApiTransactionAccountingFieldSelection": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "ID that uniquely identifies an accounting field option within Ramp"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "name of accounting field option"
+                    },
+                    "external_id": {
+                        "type": "string",
+                        "description": "external id of accounting field option; It should uniquely identify an accounting field option on the client end."
+                    },
+                    "type": {
+                        "description": "Accounting field type",
+                        "type": "string",
+                        "enum": [
+                            "AMORTIZATION_TEMPLATE",
+                            "BILLABLE",
+                            "CUSTOMERS_JOBS",
+                            "GL_ACCOUNT",
+                            "INVENTORY_ITEM",
+                            "MERCHANT",
+                            "OTHER",
+                            "SUBSIDIARY",
+                            "TAX_CODE"
+                        ]
+                    }
+                }
+            },
+            "ApiTransactionLineItem": {
+                "type": "object",
+                "properties": {
+                    "accounting_field_selections": {
+                        "description": "List of accounting field options related to the line item.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ApiTransactionAccountingFieldSelection"
+                        }
+                    },
+                    "amount": {
+                        "description": "Amount of the line item, denominated in the currency that the transaction was settled in.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/CurrencyAmount"
+                            }
+                        ]
+                    }
+                }
+            },
+            "ApiTransactionPolicyViolation": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "Type of the policy violation."
+                    },
+                    "memo": {
+                        "type": "string",
+                        "description": "Free form text regarding the policy violation."
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Uniquely identifies a policy violation."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Time at which the policy violation is created, presented in ISO8601 format."
+                    }
+                }
+            },
+            "ApiTransactionDispute": {
+                "type": "object",
+                "properties": {
+                    "type": {
+                        "type": "string",
+                        "description": "The dispute type; It could be one of the following values: RESOLVED_BY_RAMP, CANCELLED_BY_CUSTOMER, CREATED_MERCHANT_ERROR and CREATED_UNRECOGNIZED_CHARGE."
+                    },
+                    "memo": {
+                        "type": "string",
+                        "description": "Free form text regarding the dispute."
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Uniquely identifies a transaction dispute."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Time at which the dispute is created, presented in ISO8601 format."
+                    }
+                }
+            },
+            "ApiTransactionCardHolder": {
+                "type": "object",
+                "properties": {
+                    "user_id": {
+                        "type": "string",
+                        "description": "Card holder's ID."
+                    },
+                    "department_id": {
+                        "type": "string",
+                        "description": "ID of the card holder's department."
+                    },
+                    "location_id": {
+                        "type": "string",
+                        "description": "ID of the card holder's location."
+                    },
+                    "last_name": {
+                        "type": "string",
+                        "description": "Card holder's last name."
+                    },
+                    "department_name": {
+                        "type": "string",
+                        "description": "Name of the card holder's deparment."
+                    },
+                    "location_name": {
+                        "type": "string",
+                        "description": "Name of the card holder's location."
+                    },
+                    "first_name": {
+                        "type": "string",
+                        "description": "Card holder's first name."
+                    }
+                }
+            },
+            "ApiTransactionDeclineDetails": {
+                "type": "object",
+                "properties": {
+                    "reason": {
+                        "type": "string",
+                        "enum": [
+                            "AUTHORIZER",
+                            "AUTHORIZER_AP_CARD_VELOCITY_LIMIT",
+                            "AUTHORIZER_BUSINESS_LIMIT",
+                            "AUTHORIZER_BUSINESS_VENDOR_BLACKLIST",
+                            "AUTHORIZER_CARD_AUTO_LOCK_DATE",
+                            "AUTHORIZER_CARD_CATEGORY_BLACKLIST",
+                            "AUTHORIZER_CARD_CATEGORY_WHITELIST",
+                            "AUTHORIZER_CARD_LIMIT",
+                            "AUTHORIZER_CARD_MCC_BLACKLIST",
+                            "AUTHORIZER_CARD_MISSING_POLICY_ITEMS",
+                            "AUTHORIZER_CARD_NOT_ACTIVATED",
+                            "AUTHORIZER_CARD_SUSPENDED",
+                            "AUTHORIZER_CARD_VENDOR_BLACKLIST",
+                            "AUTHORIZER_CARD_VENDOR_WHITELIST",
+                            "AUTHORIZER_COMMANDO_MODE",
+                            "AUTHORIZER_FRAUD",
+                            "AUTHORIZER_GLOBAL_MCC_BLACKLIST",
+                            "AUTHORIZER_NON_AP_CARD_VELOCITY_LIMIT",
+                            "AUTHORIZER_TRANSACTION_AMOUNT_LIMIT",
+                            "AUTHORIZER_USER_LIMIT",
+                            "BLOCKED_COUNTRY",
+                            "CARD_TERMINATED",
+                            "CHIP_FAILLURE",
+                            "FORBIDDEN_CATEGORY",
+                            "MOBILE_WALLET_FAILURE",
+                            "NOT_ACTIVE",
+                            "NOT_ALLOWED",
+                            "OFAC_VERIFICATION_NEEDED",
+                            "OTHER",
+                            "PROCESSOR_CAP",
+                            "QUASI_CASH",
+                            "STRIPE_WEBHOOK_TIMEOUT",
+                            "SUSPECTED_BIN_ATTACK",
+                            "SUSPECTED_FRAUD",
+                            "USER_TERMINATED",
+                            "WRONG_ADDRESS",
+                            "WRONG_CVV",
+                            "WRONG_EXPIRATION",
+                            "WRONG_POSTAL_CODE"
+                        ]
+                    },
+                    "amount": {
+                        "type": "number"
+                    }
+                }
+            },
+            "ApiAccountingCategory": {
+                "type": "object",
+                "properties": {
+                    "tracking_category_remote_name": {
+                        "type": "string"
+                    },
+                    "category_name": {
+                        "type": "string",
+                        "description": "User-selected category name for transaction."
+                    },
+                    "category_id": {
+                        "type": "string",
+                        "description": "User-selected category id for transaction."
+                    },
+                    "tracking_category_remote_type": {
+                        "type": "string"
+                    },
+                    "tracking_category_remote_id": {
+                        "type": "string"
+                    }
+                }
+            },
+            "Transaction": {
+                "type": "object",
+                "properties": {
+                    "accounting_field_selections": {
+                        "description": "List of accounting fields related to the transaction.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ApiTransactionAccountingFieldSelection"
+                        }
+                    },
+                    "merchant_name": {
+                        "type": "string"
+                    },
+                    "line_items": {
+                        "description": "List of line items related to the transaction.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ApiTransactionLineItem"
+                        }
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "policy_violations": {
+                        "readOnly": true,
+                        "description": "A list of policy violations sorted in descending order by their creation time.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ApiTransactionPolicyViolation"
+                        }
+                    },
+                    "merchant_category_code_description": {
+                        "type": "string",
+                        "description": "Description about the merchant category code."
+                    },
+                    "disputes": {
+                        "readOnly": true,
+                        "description": "A list of disputes sorted in descending order by their creation time.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ApiTransactionDispute"
+                        }
+                    },
+                    "memo": {
+                        "type": "string",
+                        "nullable": true,
+                        "maxLength": 255
+                    },
+                    "sk_category_id": {
+                        "type": "integer",
+                        "description": "Ramp-internal category id."
+                    },
+                    "receipts": {
+                        "readOnly": true,
+                        "description": "Receipts listed in ascending order by their creation time, related to the transaction.",
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uuid"
+                        }
+                    },
+                    "card_id": {
+                        "type": "string"
+                    },
+                    "card_holder": {
+                        "description": "Information about the card holder.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ApiTransactionCardHolder"
+                            }
+                        ]
+                    },
+                    "merchant_descriptor": {
+                        "type": "string",
+                        "description": "A merchant descriptor is the name that appears on a customer's bank statement when they make a purchase from that merchant."
+                    },
+                    "original_transaction_amount": {
+                        "description": "the original transaction amount before the currency conversion.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/CurrencyAmount"
+                            }
+                        ]
+                    },
+                    "state": {
+                        "description": "transaction state.",
+                        "type": "string",
+                        "enum": [
+                            "ALL",
+                            "CLEARED",
+                            "COMPLETION",
+                            "DECLINED",
+                            "ERROR",
+                            "PENDING",
+                            "PENDING_INITIATION"
+                        ]
+                    },
+                    "user_transaction_time": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "sk_category_name": {
+                        "type": "string",
+                        "description": "Ramp-internal category name."
+                    },
+                    "amount": {
+                        "type": "number",
+                        "description": "Settled amount of the transaction."
+                    },
+                    "decline_details": {
+                        "description": "Details about a transaction decline.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ApiTransactionDeclineDetails"
+                            }
+                        ]
+                    },
+                    "accounting_categories": {
+                        "readOnly": true,
+                        "description": "Accounting categories related to the transaction.",
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ApiAccountingCategory"
+                        }
+                    },
+                    "merchant_category_code": {
+                        "type": "string",
+                        "description": "Merchant category code is a four-digit number in ISP 18245 used to classify a business by the types of goods and services it provides."
+                    },
+                    "merchant_id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "currency_code": {
+                        "type": "string",
+                        "description": "Currency that the transaction is settled in."
+                    }
+                },
+                "example": [
+                    {
+                        "accounting_categories": [],
+                        "amount": 90.0,
+                        "currency_code": "USD",
+                        "card_holder": {
+                            "department_id": "d471d830-2e73-4082-8a75-68540f83e86e",
+                            "department_name": "Executive",
+                            "first_name": "Patrick",
+                            "last_name": "Robinson",
+                            "location_id": "4fcf3423-a2e6-42f6-8dd8-9b3a8c51e069",
+                            "location_name": "San Francisco",
+                            "user_id": "a26c82c9-6b7d-4022-bc4b-a55b4c4743c7"
+                        },
+                        "card_id": "6bc41b14-f853-4862-bae5-4f122f123f6e",
+                        "disputes": [],
+                        "id": "fd14cd6a-846e-4994-9315-5a59e6bb465f",
+                        "memo": null,
+                        "merchant_category_code": null,
+                        "merchant_category_code_description": null,
+                        "merchant_descriptor": "VANTA",
+                        "merchant_id": "2907e304-cac2-4abf-84c4-b3b454ae3b8c",
+                        "merchant_name": "Vanta",
+                        "policy_violations": [],
+                        "receipts": [],
+                        "sk_category_id": 40,
+                        "sk_category_name": "SaaS / Software",
+                        "state": "CLEARED",
+                        "user_transaction_time": "2022-04-28T21:36:29.604020",
+                        "original_transaction_amount": {
+                            "amount": 9000,
+                            "currency_code": "EUR"
+                        },
+                        "accounting_field_selections": [
+                            {
+                                "ramp_id": "07b4ce4d-2750-412e-aef4-6b7815f1411c",
+                                "id": "Category",
+                                "name": "Category",
+                                "type": "GL_ACCOUNT"
+                            }
+                        ],
+                        "line_items": [
+                            {
+                                "amount": {
+                                    "amount": 5000,
+                                    "currency_code": "USD"
+                                },
+                                "accounting_field_selections": [
+                                    {
+                                        "ramp_id": "07b4ce4d-2750-412e-aef4-6b7815f1411a",
+                                        "type": "Subsidiary",
+                                        "id": "426",
+                                        "name": "Ramp BV"
+                                    }
+                                ]
+                            },
+                            {
+                                "amount": {
+                                    "amount": 4000,
+                                    "currency_code": "USD"
+                                },
+                                "accounting_field_selections": [
+                                    {
+                                        "ramp_id": "07b4ce4d-2750-412e-aef4-6b7815f1411b",
+                                        "type": "Subsidiary",
+                                        "id": "425",
+                                        "name": "Ramp LP"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            "PaginatedResponseApiTransactionCanonicalSchema": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "$ref": "#/components/schemas/DeveloperAPINestedPage"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Transaction"
+                        }
+                    }
+                },
+                "required": [
+                    "data",
+                    "page"
+                ],
+                "example": {
+                    "page": {
+                        "next": "https://api.ramp.com/developer/v1/<resources>?<new_params>"
+                    },
+                    "data": [
+                        [
+                            {
+                                "accounting_categories": [],
+                                "amount": 90.0,
+                                "currency_code": "USD",
+                                "card_holder": {
+                                    "department_id": "d471d830-2e73-4082-8a75-68540f83e86e",
+                                    "department_name": "Executive",
+                                    "first_name": "Patrick",
+                                    "last_name": "Robinson",
+                                    "location_id": "4fcf3423-a2e6-42f6-8dd8-9b3a8c51e069",
+                                    "location_name": "San Francisco",
+                                    "user_id": "a26c82c9-6b7d-4022-bc4b-a55b4c4743c7"
+                                },
+                                "card_id": "6bc41b14-f853-4862-bae5-4f122f123f6e",
+                                "disputes": [],
+                                "id": "fd14cd6a-846e-4994-9315-5a59e6bb465f",
+                                "memo": null,
+                                "merchant_category_code": null,
+                                "merchant_category_code_description": null,
+                                "merchant_descriptor": "VANTA",
+                                "merchant_id": "2907e304-cac2-4abf-84c4-b3b454ae3b8c",
+                                "merchant_name": "Vanta",
+                                "policy_violations": [],
+                                "receipts": [],
+                                "sk_category_id": 40,
+                                "sk_category_name": "SaaS / Software",
+                                "state": "CLEARED",
+                                "user_transaction_time": "2022-04-28T21:36:29.604020",
+                                "original_transaction_amount": {
+                                    "amount": 9000,
+                                    "currency_code": "EUR"
+                                },
+                                "accounting_field_selections": [
+                                    {
+                                        "ramp_id": "07b4ce4d-2750-412e-aef4-6b7815f1411c",
+                                        "id": "Category",
+                                        "name": "Category",
+                                        "type": "GL_ACCOUNT"
+                                    }
+                                ],
+                                "line_items": [
+                                    {
+                                        "amount": {
+                                            "amount": 5000,
+                                            "currency_code": "USD"
+                                        },
+                                        "accounting_field_selections": [
+                                            {
+                                                "ramp_id": "07b4ce4d-2750-412e-aef4-6b7815f1411a",
+                                                "type": "Subsidiary",
+                                                "id": "426",
+                                                "name": "Ramp BV"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "amount": {
+                                            "amount": 4000,
+                                            "currency_code": "USD"
+                                        },
+                                        "accounting_field_selections": [
+                                            {
+                                                "ramp_id": "07b4ce4d-2750-412e-aef4-6b7815f1411b",
+                                                "type": "Subsidiary",
+                                                "id": "425",
+                                                "name": "Ramp LP"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    ]
+                }
+            },
+            "User": {
+                "type": "object",
+                "properties": {
+                    "role": {
+                        "type": "string",
+                        "description": "The employee's role; It could be one of the following values: Admin, Cardholder, Owner, Bookkeeper"
+                    },
+                    "phone": {
+                        "type": "string",
+                        "description": "The employee's phone number"
+                    },
+                    "department_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the employee's department"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique employee identifier"
+                    },
+                    "business_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the company that the employee's working for."
+                    },
+                    "manager_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the employee's manager"
+                    },
+                    "is_manager": {
+                        "type": "boolean",
+                        "description": "Whether the employee is a manager"
+                    },
+                    "location_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the employee's location"
+                    },
+                    "last_name": {
+                        "type": "string",
+                        "description": "Last name of the employee"
+                    },
+                    "status": {
+                        "description": "The employee's status; It could be one of the following values: INVITE_PENDING, INVITE_DELETED, INVITE_EXPIRED, USER_ONBOARDING, USER_ACTIVE and USER_SUSPENDED",
+                        "type": "string",
+                        "enum": [
+                            "INVITE_DELETED",
+                            "INVITE_EXPIRED",
+                            "INVITE_PENDING",
+                            "USER_ACTIVE",
+                            "USER_ONBOARDING",
+                            "USER_SUSPENDED"
+                        ]
+                    },
+                    "email": {
+                        "type": "string",
+                        "description": "The employee's email address"
+                    },
+                    "first_name": {
+                        "type": "string",
+                        "description": "First name of the employee"
+                    }
+                },
+                "example": {
+                    "business_id": "9abffcf0-dd7d-42f0-b806-ce0502ab6496",
+                    "department_id": "2d68eb67-f6eb-4284-8683-7d530c77a5a6",
+                    "email": "cardholder_7@company.com",
+                    "first_name": "Linda",
+                    "id": "bde8334e-042e-4f39-9a5d-355ae17342e6",
+                    "is_manager": false,
+                    "last_name": "Gu",
+                    "location_id": "f4efe11c-221f-4b49-a1e4-33eaf96a49ee",
+                    "manager_id": "ccc5d4cc-337f-49a5-86b3-5df128233f2c",
+                    "phone": 8004559999,
+                    "role": "BUSINESS_USER",
+                    "status": "USER_ACTIVE"
+                }
+            },
+            "ApiUserUpdate": {
+                "type": "object",
+                "properties": {
+                    "role": {
+                        "type": "string",
+                        "enum": [
+                            "BUSINESS_ADMIN",
+                            "BUSINESS_USER",
+                            "BUSINESS_BOOKKEEPER"
+                        ],
+                        "description": "The employee's role; It could be one of the following values: Admin, Cardholder, Bookkeeper; Note that Owner is not a permissible value."
+                    },
+                    "direct_manager_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the employee's direct manager"
+                    },
+                    "department_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the employee's department"
+                    },
+                    "location_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the employee's location"
+                    }
+                },
+                "example": {
+                    "department_id": "2d68eb67-f6eb-4284-8683-7d530c77a5a6",
+                    "location_id": "f4efe11c-221f-4b49-a1e4-33eaf96a49ee",
+                    "direct_manager_id": "ccc5d4cc-337f-49a5-86b3-5df128233f2c"
+                }
+            },
+            "PaginatedResponseApiUserResourceSchema": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "$ref": "#/components/schemas/DeveloperAPINestedPage"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/User"
+                        }
+                    }
+                },
+                "required": [
+                    "data",
+                    "page"
+                ],
+                "example": {
+                    "page": {
+                        "next": "https://api.ramp.com/developer/v1/<resources>?<new_params>"
+                    },
+                    "data": [
+                        {
+                            "business_id": "9abffcf0-dd7d-42f0-b806-ce0502ab6496",
+                            "department_id": "2d68eb67-f6eb-4284-8683-7d530c77a5a6",
+                            "email": "cardholder_7@company.com",
+                            "first_name": "Linda",
+                            "id": "bde8334e-042e-4f39-9a5d-355ae17342e6",
+                            "is_manager": false,
+                            "last_name": "Gu",
+                            "location_id": "f4efe11c-221f-4b49-a1e4-33eaf96a49ee",
+                            "manager_id": "ccc5d4cc-337f-49a5-86b3-5df128233f2c",
+                            "phone": 8004559999,
+                            "role": "BUSINESS_USER",
+                            "status": "USER_ACTIVE"
+                        }
+                    ]
+                }
+            },
+            "ApiUserCreate": {
+                "type": "object",
+                "properties": {
+                    "role": {
+                        "type": "string",
+                        "enum": [
+                            "BUSINESS_ADMIN",
+                            "BUSINESS_USER",
+                            "BUSINESS_BOOKKEEPER"
+                        ],
+                        "description": "The employee's role; It could be one of the following values: Admin, Cardholder, Bookkeeper; Note that Owner is not a invitable role."
+                    },
+                    "phone": {
+                        "type": "string",
+                        "description": "The employee's phone number"
+                    },
+                    "department_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the employee's department"
+                    },
+                    "location_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the employee's location"
+                    },
+                    "idempotency_key": {
+                        "type": "string",
+                        "description": "an idempotency key is a unique value generated by the client which the server uses to recognize subsequent retries of the same request. To avoid collisions, we encourage clients to use random generated UUIDs."
+                    },
+                    "last_name": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "Last name of the employee"
+                    },
+                    "email": {
+                        "type": "string",
+                        "format": "email",
+                        "description": "The employee's email address"
+                    },
+                    "first_name": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "First name of the employee"
+                    },
+                    "direct_manager_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the employee's direct manager"
+                    }
+                },
+                "required": [
+                    "email",
+                    "first_name",
+                    "last_name",
+                    "phone",
+                    "role"
+                ],
+                "example": {
+                    "idempotency_key": "d471d830-2e73-4082-8a75-68540f83e86e",
+                    "first_name": "Linda",
+                    "last_name": "Gu",
+                    "email": "cardholder_7@company.com",
+                    "phone": "8004559999",
+                    "role": "BUSINESS_USER",
+                    "department_id": "2d68eb67-f6eb-4284-8683-7d530c77a5a6",
+                    "location_id": "f4efe11c-221f-4b49-a1e4-33eaf96a49ee",
+                    "direct_manager_id": "ccc5d4cc-337f-49a5-86b3-5df128233f2c"
+                }
+            },
+            "ApiUserDeferredTaskData": {
+                "type": "object",
+                "properties": {
+                    "user_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "The subject employee's ID of the deferred task."
+                    },
+                    "error": {
+                        "type": "string",
+                        "description": "An error message if the deferred task fails"
+                    }
+                }
+            },
+            "UserDeferredTask": {
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "description": "Status of the deferred task. It could be one of the following values: STARTED, IN_PROGRESS, ERROR, SUCCESS"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Unique identifier of the deferred task."
+                    },
+                    "data": {
+                        "description": "Detailed data of the deferred task.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ApiUserDeferredTaskData"
+                            }
+                        ]
+                    }
+                },
+                "example": {
+                    "id": "2d68eb67-f6eb-4284-8683-7d530c77a5a6",
+                    "data": {
+                        "user_id": "f4efe11c-221f-4b49-a1e4-33eaf96a49ee"
+                    },
+                    "status": "SUCCESS"
+                }
+            },
+            "Memo": {
+                "type": "object",
+                "properties": {
+                    "memo": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    }
+                }
+            },
+            "PaginatedResponseApiMemoResourceSchema": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "$ref": "#/components/schemas/DeveloperAPINestedPage"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Memo"
+                        }
+                    }
+                },
+                "required": [
+                    "data",
+                    "page"
+                ],
+                "example": {
+                    "page": {
+                        "next": "https://api.ramp.com/developer/v1/<resources>?<new_params>"
+                    },
+                    "data": [
+                        {}
+                    ]
+                }
+            },
+            "Merchant": {
+                "type": "object",
+                "properties": {
+                    "sk_category_name": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "merchant_name": {
+                        "type": "string"
+                    }
+                }
+            },
+            "PaginatedResponseApiMerchantResourceSchema": {
+                "type": "object",
+                "properties": {
+                    "page": {
+                        "$ref": "#/components/schemas/DeveloperAPINestedPage"
+                    },
+                    "data": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Merchant"
+                        }
+                    }
+                },
+                "required": [
+                    "data",
+                    "page"
+                ],
+                "example": {
+                    "page": {
+                        "next": "https://api.ramp.com/developer/v1/<resources>?<new_params>"
+                    },
+                    "data": [
+                        {}
+                    ]
+                }
+            },
+            "ApiSalesLeadOfficeAddress": {
+                "type": "object",
+                "properties": {
+                    "office_postal_code": {
+                        "type": "string"
+                    },
+                    "office_state": {
+                        "type": "string"
+                    },
+                    "office_city": {
+                        "type": "string"
+                    },
+                    "office_street_address": {
+                        "type": "string"
+                    },
+                    "office_apt_suite": {
+                        "type": "string"
+                    },
+                    "office_country": {
+                        "type": "string"
+                    }
+                }
+            },
+            "ApiSalesLeadBusinessDump": {
+                "type": "object",
+                "properties": {
+                    "office_address": {
+                        "description": "Office's address.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ApiSalesLeadOfficeAddress"
+                            }
+                        ]
+                    },
+                    "date_of_incorporation": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Business's incorporation date."
+                    },
+                    "state_of_incorporation": {
+                        "type": "string",
+                        "description": "The state in which the business is incorporated."
+                    },
+                    "business_description": {
+                        "type": "string",
+                        "description": "A short description of the business."
+                    },
+                    "ein_number": {
+                        "type": "string",
+                        "description": "Employer Identification Number (EIN)."
+                    },
+                    "sector": {
+                        "type": "string",
+                        "description": "Business's sector"
+                    },
+                    "business_name_website": {
+                        "type": "string",
+                        "description": "Business's website."
+                    },
+                    "estimated_monthly_spend": {
+                        "type": "string",
+                        "description": "Estimated monthly spend."
+                    },
+                    "business_name_legal": {
+                        "type": "string",
+                        "description": "Legal name of the business."
+                    },
+                    "industry": {
+                        "type": "string",
+                        "description": "Business's industry"
+                    },
+                    "business_name_dba": {
+                        "type": "string",
+                        "description": "Doing business as (DBA)"
+                    },
+                    "industry_group": {
+                        "type": "string",
+                        "description": "Business's industry group"
+                    },
+                    "office_phone_number": {
+                        "type": "string",
+                        "description": "Office phone number. Must include country code."
+                    },
+                    "entity_type": {
+                        "description": "Type of incorporation.",
+                        "type": "string",
+                        "enum": [
+                            "COOPERATIVE",
+                            "CORPORATION",
+                            "LLC",
+                            "OTHER",
+                            "PARTNERSHIP",
+                            "SOLE_PROPRIETORSHIP"
+                        ]
+                    },
+                    "sub_industry": {
+                        "type": "string",
+                        "description": ""
+                    }
+                },
+                "example": {
+                    "date_of_incorporation": "2004-01-01",
+                    "state_of_incorporation": "New Mexico",
+                    "ein_number": "12-3456789",
+                    "business_description": "We are in the empire business",
+                    "business_name_dba": "White & Pinkman Inc.",
+                    "entity_type": "CORPORATION",
+                    "business_name_legal": "White & Pinkman Inc.",
+                    "sector": "Consumer Staples",
+                    "industry_group": "Food, Beverage & Tobacco",
+                    "industry": "Food Products",
+                    "estimated_monthly_spend": "10,000",
+                    "business_name_website": "www.whiteandpinkman.com",
+                    "office_address": {
+                        "office_city": "Albuquerque",
+                        "office_postal_code": "100022",
+                        "office_state": "New Mexico",
+                        "office_country": "US",
+                        "office_street_address": "100 Main Street"
+                    }
+                }
+            },
+            "Lead": {
+                "type": "object",
+                "properties": {
+                    "phone": {
+                        "type": "string"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "source": {
+                        "type": "string",
+                        "enum": [
+                            "AngelList"
+                        ]
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "financing_application_status": {
+                        "type": "string",
+                        "enum": [
+                            "ALLOY_COMPLETE",
+                            "Admin Approved",
+                            "DOCUMENTS_REQUIRED",
+                            "DOCUMENTS_SUBMITTED",
+                            "KYC Approved",
+                            "OPS_REVIEW",
+                            "Pending",
+                            "Rejected",
+                            "Submitted",
+                            "Withdrawn"
+                        ]
+                    },
+                    "last_name": {
+                        "type": "string"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "first_name": {
+                        "type": "string"
+                    },
+                    "external_id": {
+                        "type": "string"
+                    },
+                    "business_info": {
+                        "$ref": "#/components/schemas/ApiSalesLeadBusinessDump"
+                    }
+                },
+                "required": [
+                    "external_id",
+                    "source"
+                ],
+                "example": {
+                    "id": "97ad0c67-c318-4591-9b0e-202ecceb8016",
+                    "created_at": "",
+                    "updated_at": "",
+                    "source": "White & Pinkman",
+                    "external_id": "f26bfdb5-beei-4875-a9b5-a29f8af6f381",
+                    "email": "lead@whiteandpinkman.com",
+                    "first_name": "Walter",
+                    "last_name": "White",
+                    "business_info": {
+                        "date_of_incorporation": "2004-01-01",
+                        "state_of_incorporation": "New Mexico",
+                        "ein_number": "12-3456789",
+                        "business_description": "We are in the empire business",
+                        "business_name_dba": "White & Pinkman Inc.",
+                        "entity_type": "CORPORATION",
+                        "business_name_legal": "White & Pinkman Inc.",
+                        "sector": "Consumer Staples",
+                        "industry_group": "Food, Beverage & Tobacco",
+                        "industry": "Food Products",
+                        "estimated_monthly_spend": "10,000",
+                        "business_name_website": "www.whiteandpinkman.com",
+                        "office_address": {
+                            "office_city": "Albuquerque",
+                            "office_postal_code": "100022",
+                            "office_state": "New Mexico",
+                            "office_country": "US",
+                            "office_street_address": "100 Main Street"
+                        }
+                    }
+                }
+            },
+            "ApiSalesLeadBusinessLoad": {
+                "type": "object",
+                "properties": {
+                    "office_address": {
+                        "description": "Office's address.",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ApiSalesLeadOfficeAddress"
+                            }
+                        ]
+                    },
+                    "date_of_incorporation": {
+                        "type": "string",
+                        "format": "date",
+                        "description": "Business's incorporation date."
+                    },
+                    "state_of_incorporation": {
+                        "type": "string",
+                        "description": "The state in which the business is incorporated."
+                    },
+                    "business_description": {
+                        "type": "string",
+                        "description": "A short description of the business."
+                    },
+                    "ein_number": {
+                        "type": "string",
+                        "description": "Employer Identification Number (EIN)."
+                    },
+                    "sector": {
+                        "type": "string",
+                        "description": "Business's sector"
+                    },
+                    "business_name_website": {
+                        "type": "string",
+                        "description": "Business's website."
+                    },
+                    "estimated_monthly_spend": {
+                        "type": "string",
+                        "description": "Estimated monthly spend."
+                    },
+                    "business_name_legal": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "Legal name of the business."
+                    },
+                    "industry": {
+                        "type": "string",
+                        "description": "Business's industry"
+                    },
+                    "business_name_dba": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "description": "Doing business as (DBA)"
+                    },
+                    "industry_group": {
+                        "type": "string",
+                        "description": "Business's industry group"
+                    },
+                    "office_phone_number": {
+                        "type": "string",
+                        "description": "Office phone number. Must include country code."
+                    },
+                    "entity_type": {
+                        "description": "Type of incorporation.",
+                        "type": "string",
+                        "enum": [
+                            "COOPERATIVE",
+                            "CORPORATION",
+                            "LLC",
+                            "OTHER",
+                            "PARTNERSHIP",
+                            "SOLE_PROPRIETORSHIP"
+                        ]
+                    },
+                    "sub_industry": {
+                        "type": "string",
+                        "description": "Business's subindustry"
+                    }
+                },
+                "required": [
+                    "business_name_dba",
+                    "business_name_legal"
+                ],
+                "example": {
+                    "date_of_incorporation": "2004-01-01",
+                    "state_of_incorporation": "New Mexico",
+                    "ein_number": "12-3456789",
+                    "business_description": "We are in the empire business",
+                    "business_name_dba": "White & Pinkman Inc.",
+                    "entity_type": "CORPORATION",
+                    "business_name_legal": "White & Pinkman Inc.",
+                    "sector": "Consumer Staples",
+                    "industry_group": "Food, Beverage & Tobacco",
+                    "industry": "Food Products",
+                    "estimated_monthly_spend": "10,000",
+                    "business_name_website": "www.whiteandpinkman.com",
+                    "office_address": {
+                        "office_city": "Albuquerque",
+                        "office_postal_code": "100022",
+                        "office_state": "New Mexico",
+                        "office_country": "US",
+                        "office_street_address": "100 Main Street"
+                    }
+                }
+            },
+            "ApiSalesLeadCreate": {
+                "type": "object",
+                "properties": {
+                    "phone": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "state": {
+                        "type": "string"
+                    },
+                    "source": {
+                        "description": "",
+                        "type": "string",
+                        "enum": [
+                            "AngelList"
+                        ]
+                    },
+                    "last_name": {
+                        "type": "string",
+                        "maxLength": 40,
+                        "description": ""
+                    },
+                    "redirect_uri": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "email": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "first_name": {
+                        "type": "string",
+                        "maxLength": 40,
+                        "description": ""
+                    },
+                    "external_id": {
+                        "type": "string",
+                        "description": ""
+                    },
+                    "business_info": {
+                        "description": "",
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ApiSalesLeadBusinessLoad"
+                            }
+                        ]
+                    }
+                },
+                "required": [
+                    "email",
+                    "external_id",
+                    "first_name",
+                    "last_name",
+                    "redirect_uri",
+                    "source",
+                    "state"
+                ],
+                "example": {
+                    "source": "White & Pinkman",
+                    "external_id": "f26bfdb5-beei-4875-a9b5-a29f8af6f381",
+                    "redirect_uri": "https://app.whiteandpinkman.com/ramp/callback",
+                    "state": "f26bfdb5-7ecf-4875-a9b5-a29f8af6f381",
+                    "email": "lead@whiteandpinkman.com",
+                    "first_name": "Walter",
+                    "last_name": "White",
+                    "business_info": {
+                        "date_of_incorporation": "2004-01-01",
+                        "state_of_incorporation": "New Mexico",
+                        "ein_number": "12-3456789",
+                        "business_description": "We are in the empire business",
+                        "business_name_dba": "White & Pinkman Inc.",
+                        "entity_type": "CORPORATION",
+                        "business_name_legal": "White & Pinkman Inc.",
+                        "sector": "Consumer Staples",
+                        "industry_group": "Food, Beverage & Tobacco",
+                        "industry": "Food Products",
+                        "estimated_monthly_spend": "10,000",
+                        "business_name_website": "www.whiteandpinkman.com",
+                        "office_address": {
+                            "office_city": "Albuquerque",
+                            "office_postal_code": "100022",
+                            "office_state": "New Mexico",
+                            "office_country": "US",
+                            "office_street_address": "100 Main Street"
+                        }
+                    }
+                }
+            },
+            "Upload": {
+                "type": "object",
+                "properties": {
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "document_type": {
+                        "type": "string"
+                    },
+                    "sales_lead_id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                }
+            },
+            "ApiReceiptIntegrationOptedOutEmailResource": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid"
+                    },
+                    "email": {
+                        "type": "string",
+                        "format": "email"
+                    }
+                }
+            },
+            "ApiReceiptIntegrationOptedOutEmailCreate": {
+                "type": "object",
+                "properties": {
+                    "business_id": {
+                        "type": "integer"
+                    },
+                    "email": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "business_id",
+                    "email"
+                ]
+            }
+        },
+        "securitySchemes": {
+            "oauth2": {
+                "type": "oauth2",
+                "flows": {
+                    "authorizationCode": {
+                        "tokenUrl": "https://api.ramp.com/developer/v1/token",
+                        "authorizationUrl": "https://api.ramp.com/v1/authorize",
+                        "scopes": {
+                            "transactions:read": "Grant read access to transactions",
+                            "cards:read": "Grant read access to cards",
+                            "cards:read_vault": "Grant read_vault access to cards",
+                            "cards:write": "Grant write access to cards",
+                            "card_programs:read": "Grant read access to card_programs",
+                            "card_programs:write": "Grant write access to card_programs",
+                            "users:read": "Grant read access to users",
+                            "users:write": "Grant write access to users",
+                            "locations:read": "Grant read access to locations",
+                            "locations:write": "Grant write access to locations",
+                            "departments:read": "Grant read access to departments",
+                            "departments:write": "Grant write access to departments",
+                            "business:read": "Grant read access to business",
+                            "receipts:read": "Grant read access to receipts",
+                            "reimbursements:read": "Grant read access to reimbursements",
+                            "memos:read": "Grant read access to memos",
+                            "merchants:read": "Grant read access to merchants",
+                            "transfers:read": "Grant read access to transfers",
+                            "leads:read": "Grant read access to leads",
+                            "leads:write": "Grant write access to leads",
+                            "accounting:read": "Grant read access to accounting",
+                            "accounting:write": "Grant write access to accounting",
+                            "receipt_integrations:read": "Grant read access to receipt_integrations",
+                            "receipt_integrations:write": "Grant write access to receipt_integrations",
+                            "spend_limits:read": "Grant read access to spend_limits",
+                            "spend_limits:write": "Grant write access to spend_limits",
+                            "spend_programs:read": "Grant read access to spend_programs",
+                            "spend_programs:write": "Grant write access to spend_programs",
+                            "rls_users:read": "Grant read access to rls_users",
+                            "cashbacks:read": "Grant read access to cashbacks"
+                        }
+                    },
+                    "clientCredentials": {
+                        "tokenUrl": "https://api.ramp.com/developer/v1/token",
+                        "scopes": {
+                            "transactions:read": "Grant read access to transactions",
+                            "cards:read": "Grant read access to cards",
+                            "cards:read_vault": "Grant read_vault access to cards",
+                            "cards:write": "Grant write access to cards",
+                            "card_programs:read": "Grant read access to card_programs",
+                            "card_programs:write": "Grant write access to card_programs",
+                            "users:read": "Grant read access to users",
+                            "users:write": "Grant write access to users",
+                            "locations:read": "Grant read access to locations",
+                            "locations:write": "Grant write access to locations",
+                            "departments:read": "Grant read access to departments",
+                            "departments:write": "Grant write access to departments",
+                            "business:read": "Grant read access to business",
+                            "receipts:read": "Grant read access to receipts",
+                            "reimbursements:read": "Grant read access to reimbursements",
+                            "memos:read": "Grant read access to memos",
+                            "merchants:read": "Grant read access to merchants",
+                            "transfers:read": "Grant read access to transfers",
+                            "leads:read": "Grant read access to leads",
+                            "leads:write": "Grant write access to leads",
+                            "accounting:read": "Grant read access to accounting",
+                            "accounting:write": "Grant write access to accounting",
+                            "receipt_integrations:read": "Grant read access to receipt_integrations",
+                            "receipt_integrations:write": "Grant write access to receipt_integrations",
+                            "spend_limits:read": "Grant read access to spend_limits",
+                            "spend_limits:write": "Grant write access to spend_limits",
+                            "spend_programs:read": "Grant read access to spend_programs",
+                            "spend_programs:write": "Grant write access to spend_programs",
+                            "rls_users:read": "Grant read access to rls_users",
+                            "cashbacks:read": "Grant read access to cashbacks"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "x-tagGroups": [
+        {
+            "name": "Developer Api",
+            "tags": [
+                "Business",
+                "Card",
+                "Card Program",
+                "Custom Id Provider",
+                "Department",
+                "Location",
+                "Memo",
+                "Merchant",
+                "Receipt",
+                "Receipt Integrations",
+                "Reimbursement",
+                "SalesLead",
+                "Token",
+                "Transaction",
+                "User"
+            ]
+        },
+        {
+            "name": "Unowned",
+            "tags": []
+        }
+    ]
+}


### PR DESCRIPTION
This problem showed up when running `openapitor` on Ramp. The code was totally valid, but `cargo doc` gave warnings and `cargo test --doc` failed. Here are screenshots from Rustdoc on the relevant field,

Before this PR:
<img width="1026" alt="Screenshot 2023-04-03 at 1 35 09 PM" src="https://user-images.githubusercontent.com/5407457/229598138-c77f5247-7ade-4589-b969-3019173129c6.png">

After this PR:
<img width="1012" alt="Screenshot 2023-04-03 at 1 58 20 PM" src="https://user-images.githubusercontent.com/5407457/229601730-969400a3-f5db-4e4d-b605-2493d08b40cf.png">

I added a unit test for the Ramp API, to make sure its codegen passes `cargo test`. The test failed before my changes to `openapitor/src/types/mod.rs` and passes afterwards.