### PR TITLE
Improve GitHub actions

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Install latest stable/nightly
         shell: bash
         run: |
@@ -22,35 +23,19 @@ jobs:
           rustup component add rustfmt --toolchain nightly
           rustup component add clippy
           echo PATH="${HOME}/.cargo/bin:${PATH}" >> ${GITHUB_ENV}
-      - name: Cache cargo registry
-        uses: actions/cache@v3.0.6
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo index
-        uses: actions/cache@v3.0.6
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-      - name: Cache cargo build
-        uses: actions/cache@v3.0.6
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-      - name: Run cargo test
-        run: |
-          cargo test --all
+
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@nextest
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.2.1
+
+      - name: cargo test
         shell: bash
+        run: |
+          cargo llvm-cov nextest --all --exclude engine --lcov --output-path lcov.info --test-threads=1
         env:
           KITTYCAD_API_TOKEN: ${{secrets.KITTYCAD_API_TOKEN}}
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: '0.15.0'
-          args: '--timeout 2000'
-        env:
-          KITTYCAD_API_TOKEN: ${{secrets.KITTYCAD_API_TOKEN}}
-          RUST_BACKTRACE: 1
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
@@ -59,3 +44,4 @@ jobs:
           fail_ci_if_error: true
           flags: unittests
           verbose: true
+          files: lcov.info


### PR DESCRIPTION
 - Use llvm-cov instead of tarpaulin. This is faster and more reliable.
 - Copy how api-deux installs rust deps