### PR TITLE
Fix: Invalid hostnames being randomly generated

### DIFF
--- a/openapitor/src/functions.rs
+++ b/openapitor/src/functions.rs
@@ -1205,7 +1205,7 @@ fn generate_example_code_fn(
     let args = if raw_args.is_empty() {
         quote!()
     } else {
-        let a = raw_args.iter().map(|(_k, v)| quote!(#v));
+        let a = raw_args.values().map(|v| quote!(#v));
         quote!(#(#a),*,)
     };
 

--- a/openapitor/src/tests.rs
+++ b/openapitor/src/tests.rs
@@ -9,10 +9,10 @@ impl TestContext {
     pub fn new() -> Result<Self> {
         // Create a temporary directory for the test.
         let tmp_dir = std::env::temp_dir();
-        let tmp_dir = tmp_dir.join(&format!("openapitor-{}", uuid::Uuid::new_v4()));
+        let tmp_dir = tmp_dir.join(format!("openapitor-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&tmp_dir)?;
-        let src_dir = tmp_dir.clone().join("src");
-        std::fs::create_dir_all(&src_dir)?;
+        let src_dir = tmp_dir.join("src");
+        std::fs::create_dir_all(src_dir)?;
 
         Ok(TestContext { tmp_dir })
     }
@@ -74,7 +74,7 @@ fn test_kittycad_generation(ctx: &mut TestContext) {
 
     // Make the output tests directory.
     let output_tests_dir = ctx.tmp_dir.join("tests");
-    std::fs::create_dir_all(&output_tests_dir).unwrap();
+    std::fs::create_dir_all(output_tests_dir).unwrap();
 
     // Run tests.
     run_cargo_test(&opts).unwrap();
@@ -105,7 +105,7 @@ fn test_github_generation(ctx: &mut TestContext) {
     let test_file = include_str!("../tests/library/github.tests.rs");
     // Write our temporary file.
     let test_file_path = ctx.tmp_dir.join("src").join("tests.rs");
-    std::fs::write(&test_file_path, test_file).unwrap();
+    std::fs::write(test_file_path, test_file).unwrap();
 
     // Generate the library.
     crate::generate(&spec, &opts).unwrap();
@@ -141,7 +141,7 @@ fn test_oxide_generation(ctx: &mut TestContext) {
     let test_file = include_str!("../tests/library/oxide.tests.rs");
     // Write our temporary file.
     let test_file_path = ctx.tmp_dir.join("src").join("tests.rs");
-    std::fs::write(&test_file_path, test_file).unwrap();
+    std::fs::write(test_file_path, test_file).unwrap();
 
     // Generate the library.
     crate::generate(&spec, &opts).unwrap();
@@ -175,7 +175,7 @@ fn test_front_generation(ctx: &mut TestContext) {
     let test_file = include_str!("../tests/library/front.tests.rs");
     // Write our temporary file.
     let test_file_path = ctx.tmp_dir.join("src").join("tests.rs");
-    std::fs::write(&test_file_path, test_file).unwrap();
+    std::fs::write(test_file_path, test_file).unwrap();
 
     // Generate the library.
     crate::generate(&spec, &opts).unwrap();
@@ -210,7 +210,7 @@ fn test_gusto_generation(ctx: &mut TestContext) {
     let test_file = include_str!("../tests/library/gusto.tests.rs");
     // Write our temporary file.
     let test_file_path = ctx.tmp_dir.join("src").join("tests.rs");
-    std::fs::write(&test_file_path, test_file).unwrap();
+    std::fs::write(test_file_path, test_file).unwrap();
 
     // Generate the library.
     crate::generate(&spec, &opts).unwrap();
@@ -249,7 +249,7 @@ fn test_ramp_generation(ctx: &mut TestContext) {
     let test_file = include_str!("../tests/library/ramp.tests.rs");
     // Write our temporary file.
     let test_file_path = ctx.tmp_dir.join("src").join("tests.rs");
-    std::fs::write(&test_file_path, test_file).unwrap();
+    std::fs::write(test_file_path, test_file).unwrap();
 
     // Generate the library.
     crate::generate(&spec, &opts).unwrap();

--- a/openapitor/src/types/phone_number.rs
+++ b/openapitor/src/types/phone_number.rs
@@ -56,17 +56,11 @@ impl std::str::FromStr for PhoneNumber {
         }
 
         let s = if !s.trim().starts_with('+') {
-            format!("+1{}", s)
-                .replace('-', "")
-                .replace('(', "")
-                .replace(')', "")
-                .replace(' ', "")
+            format!("+1{s}")
         } else {
-            s.replace('-', "")
-                .replace('(', "")
-                .replace(')', "")
-                .replace(' ', "")
-        };
+            s.to_string()
+        }
+        .replace(['-', '(', ')', ' '], "");
 
         Ok(PhoneNumber(Some(phonenumber::parse(None, &s).map_err(
             |e| anyhow::anyhow!("invalid phone number `{}`: {}", s, e),

--- a/openapitor/src/types/random.rs
+++ b/openapitor/src/types/random.rs
@@ -19,7 +19,7 @@ impl Random for crate::types::phone_number::PhoneNumber {
         let mut rng = rand::thread_rng();
         let mut number = String::new();
         for _ in 0..10 {
-            number.push(rng.gen_range('0'..='9') as char);
+            number.push(rng.gen_range('0'..='9'));
         }
         Self::from_str(&number)
     }

--- a/openapitor/src/types/random.rs
+++ b/openapitor/src/types/random.rs
@@ -94,26 +94,16 @@ impl Random for u64 {
 impl Random for std::net::Ipv4Addr {
     fn random() -> Result<Self> {
         let mut rng = rand::thread_rng();
-        // Return a random IPv4 address.
-        let mut ip = String::new();
-        for _ in 0..4 {
-            write!(ip, "{}.", rng.gen_range(0..255))?;
-        }
-        ip.pop();
-        Ok(ip.parse()?)
+        let [a, b, c, d]: [u8; 4] = rng.gen();
+        Ok(Self::new(a, b, c, d))
     }
 }
 
 impl Random for std::net::Ipv6Addr {
     fn random() -> Result<Self> {
         let mut rng = rand::thread_rng();
-        // Return a random IPv6 address.
-        let mut ip = String::new();
-        for _ in 0..8 {
-            write!(ip, "{:x}:", rng.gen_range(0..16))?;
-        }
-        ip.pop();
-        Ok(ip.parse()?)
+        let [a, b, c, d, e, f, g, h]: [u16; 8] = rng.gen();
+        Ok(Self::new(a, b, c, d, e, f, g, h))
     }
 }
 
@@ -121,12 +111,12 @@ impl Random for std::net::IpAddr {
     fn random() -> Result<Self> {
         // Generate a random IPv4 or IPv6 address.
         let mut rng = rand::thread_rng();
-        let ip_version = rng.gen_range(0..2);
-        match ip_version {
-            0 => Ok(std::net::IpAddr::V4(std::net::Ipv4Addr::random()?)),
-            1 => Ok(std::net::IpAddr::V6(std::net::Ipv6Addr::random()?)),
-            _ => unreachable!(),
-        }
+        let is_v4 = rng.gen();
+        Ok(if is_v4 {
+            std::net::IpAddr::V4(std::net::Ipv4Addr::random()?)
+        } else {
+            std::net::IpAddr::V6(std::net::Ipv6Addr::random()?)
+        })
     }
 }
 
@@ -134,13 +124,9 @@ impl Random for url::Url {
     fn random() -> Result<Self> {
         // Generate a random url.
         let mut rng = rand::thread_rng();
-        let scheme = rng.gen_range(0..2);
         let mut url = String::new();
-        match scheme {
-            0 => url.push_str("http://"),
-            1 => url.push_str("https://"),
-            _ => unreachable!(),
-        }
+        let is_http = rng.gen();
+        url.push_str(if is_http { "http://" } else { "https://" });
         let host: String = (0..rng.gen_range(1..10usize))
             .map(|_| {
                 // Generate a random subdomain


### PR DESCRIPTION
Our random_url() function generates URLs with numeric hostnames, e.g. `https://1.2.3`.

Problem is, the Rust URL library interprets that hostname as an IPv4. So occasionally, if we generate a long hostname like 1.2.3.4.5.6, the Url::parse method fails with an "invalid IPv4" error, failing the `test_random_url` unit test.

Also fix clippy lints.