### PR TITLE
Bump tabled crate 0.8 -> 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,20 +47,21 @@ dependencies = [
 
 [[package]]
 name = "ansi-str"
-version = "0.3.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50acdf02a3ac61856d5c8d576a8b5fb452a6549f667ca29fefaa18c2cd05135"
+checksum = "1cf4578926a981ab0ca955dc023541d19de37112bc24c1a197bd806d3d86ad1d"
 dependencies = [
  "ansitok",
 ]
 
 [[package]]
 name = "ansitok"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c6eb31f539d8fc1df948eb26452d6c781be4c9883663e7acb258644b71d5b1"
+checksum = "220044e6a1bb31ddee4e3db724d29767f352de47445a6cd75e1a173142136c83"
 dependencies = [
  "nom",
+ "vte",
 ]
 
 [[package]]
@@ -1309,14 +1310,14 @@ dependencies = [
 
 [[package]]
 name = "papergrid"
-version = "0.5.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453cf71f2a37af495a1a124bf30d4d7469cfbea58e9f2479be9d222396a518a2"
+checksum = "ae7891b22598926e4398790c8fe6447930c72a67d36d983a49d6ce682ce83290"
 dependencies = [
  "ansi-str",
+ "ansitok",
  "bytecount",
  "fnv",
- "strip-ansi-escapes",
  "unicode-width",
 ]
 
@@ -2076,15 +2077,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "strip-ansi-escapes"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
-dependencies = [
- "vte",
-]
-
-[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2137,11 +2129,12 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.8.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5b2f8c37d26d87d2252187b0a45ea3cbf42baca10377c7e7eaaa2800fa9bf97"
+checksum = "0ce69a5028cd9576063ec1f48edb2c75339fd835e6094ef3e05b3a079bf594a6"
 dependencies = [
  "ansi-str",
+ "ansitok",
  "papergrid",
  "tabled_derive",
  "unicode-width",
@@ -2149,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "tabled_derive"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ee618502f497abf593e1c5c9577f34775b111480009ffccd7ad70d23fcaba8"
+checksum = "99f688a08b54f4f02f0a3c382aefdb7884d3d69609f785bd253dc033243e3fe4"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/kittycad/Cargo.toml
+++ b/kittycad/Cargo.toml
@@ -36,7 +36,7 @@ schemars = { version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_urlencoded = "^0.7"
-tabled = { version = "0.8.0", features = ["color"] }
+tabled = { version = "0.12.0", features = ["color"] }
 thiserror = "1"
 tokio = { version = "1.20.1", features = ["sync"] }
 tracing = "^0.1"

--- a/kittycad/src/types.rs
+++ b/kittycad/src/types.rs
@@ -460,28 +460,24 @@ impl std::fmt::Display for AiPluginApi {
 
 impl tabled::Tabled for AiPluginApi {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(is_user_authenticated) = &self.is_user_authenticated {
-                format!("{:?}", is_user_authenticated)
+                format!("{:?}", is_user_authenticated).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(type_) = &self.type_ {
-                format!("{:?}", type_)
+                format!("{:?}", type_).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.url.clone(),
+            self.url.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "is_user_authenticated".to_string(),
-            "type_".to_string(),
-            "url".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["is_user_authenticated".into(), "type_".into(), "url".into()]
     }
 }
 
@@ -535,23 +531,23 @@ impl std::fmt::Display for AiPluginAuth {
 
 impl tabled::Tabled for AiPluginAuth {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(authorization_type) = &self.authorization_type {
-                format!("{:?}", authorization_type)
+                format!("{:?}", authorization_type).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(type_) = &self.type_ {
-                format!("{:?}", type_)
+                format!("{:?}", type_).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["authorization_type".to_string(), "type_".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["authorization_type".into(), "type_".into()]
     }
 }
 
@@ -659,57 +655,57 @@ impl std::fmt::Display for AiPluginManifest {
 
 impl tabled::Tabled for AiPluginManifest {
     const LENGTH: usize = 10;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.api),
-            format!("{:?}", self.auth),
+            format!("{:?}", self.api).into(),
+            format!("{:?}", self.auth).into(),
             if let Some(contact_email) = &self.contact_email {
-                format!("{:?}", contact_email)
+                format!("{:?}", contact_email).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(description_for_human) = &self.description_for_human {
-                format!("{:?}", description_for_human)
+                format!("{:?}", description_for_human).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(description_for_model) = &self.description_for_model {
-                format!("{:?}", description_for_model)
+                format!("{:?}", description_for_model).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.legal_info_url.clone(),
-            self.logo_url.clone(),
+            self.legal_info_url.clone().into(),
+            self.logo_url.clone().into(),
             if let Some(name_for_human) = &self.name_for_human {
-                format!("{:?}", name_for_human)
+                format!("{:?}", name_for_human).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name_for_model) = &self.name_for_model {
-                format!("{:?}", name_for_model)
+                format!("{:?}", name_for_model).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(schema_version) = &self.schema_version {
-                format!("{:?}", schema_version)
+                format!("{:?}", schema_version).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "api".to_string(),
-            "auth".to_string(),
-            "contact_email".to_string(),
-            "description_for_human".to_string(),
-            "description_for_model".to_string(),
-            "legal_info_url".to_string(),
-            "logo_url".to_string(),
-            "name_for_human".to_string(),
-            "name_for_model".to_string(),
-            "schema_version".to_string(),
+            "api".into(),
+            "auth".into(),
+            "contact_email".into(),
+            "description_for_human".into(),
+            "description_for_model".into(),
+            "legal_info_url".into(),
+            "logo_url".into(),
+            "name_for_human".into(),
+            "name_for_model".into(),
+            "schema_version".into(),
         ]
     }
 }
@@ -735,12 +731,15 @@ impl std::fmt::Display for ApiCallQueryGroup {
 
 impl tabled::Tabled for ApiCallQueryGroup {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.count), self.query.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            format!("{:?}", self.count).into(),
+            self.query.clone().into(),
+        ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["count".to_string(), "query".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["count".into(), "query".into()]
     }
 }
 
@@ -894,121 +893,121 @@ impl std::fmt::Display for ApiCallWithPrice {
 
 impl tabled::Tabled for ApiCallWithPrice {
     const LENGTH: usize = 22;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(duration) = &self.duration {
-                format!("{:?}", duration)
+                format!("{:?}", duration).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(email) = &self.email {
-                format!("{:?}", email)
+                format!("{:?}", email).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(endpoint) = &self.endpoint {
-                format!("{:?}", endpoint)
+                format!("{:?}", endpoint).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(ip_address) = &self.ip_address {
-                format!("{:?}", ip_address)
+                format!("{:?}", ip_address).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(litterbox) = &self.litterbox {
-                format!("{:?}", litterbox)
+                format!("{:?}", litterbox).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.method),
+            format!("{:?}", self.method).into(),
             if let Some(minutes) = &self.minutes {
-                format!("{:?}", minutes)
+                format!("{:?}", minutes).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(origin) = &self.origin {
-                format!("{:?}", origin)
+                format!("{:?}", origin).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(price) = &self.price {
-                format!("{:?}", price)
+                format!("{:?}", price).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(request_body) = &self.request_body {
-                format!("{:?}", request_body)
+                format!("{:?}", request_body).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(request_query_params) = &self.request_query_params {
-                format!("{:?}", request_query_params)
+                format!("{:?}", request_query_params).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(response_body) = &self.response_body {
-                format!("{:?}", response_body)
+                format!("{:?}", response_body).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(status_code) = &self.status_code {
-                format!("{:?}", status_code)
+                format!("{:?}", status_code).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(stripe_invoice_item_id) = &self.stripe_invoice_item_id {
-                format!("{:?}", stripe_invoice_item_id)
+                format!("{:?}", stripe_invoice_item_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.token),
-            format!("{:?}", self.updated_at),
-            self.user_agent.clone(),
+            format!("{:?}", self.token).into(),
+            format!("{:?}", self.updated_at).into(),
+            self.user_agent.clone().into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "duration".to_string(),
-            "email".to_string(),
-            "endpoint".to_string(),
-            "id".to_string(),
-            "ip_address".to_string(),
-            "litterbox".to_string(),
-            "method".to_string(),
-            "minutes".to_string(),
-            "origin".to_string(),
-            "price".to_string(),
-            "request_body".to_string(),
-            "request_query_params".to_string(),
-            "response_body".to_string(),
-            "started_at".to_string(),
-            "status_code".to_string(),
-            "stripe_invoice_item_id".to_string(),
-            "token".to_string(),
-            "updated_at".to_string(),
-            "user_agent".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "duration".into(),
+            "email".into(),
+            "endpoint".into(),
+            "id".into(),
+            "ip_address".into(),
+            "litterbox".into(),
+            "method".into(),
+            "minutes".into(),
+            "origin".into(),
+            "price".into(),
+            "request_body".into(),
+            "request_query_params".into(),
+            "response_body".into(),
+            "started_at".into(),
+            "status_code".into(),
+            "stripe_invoice_item_id".into(),
+            "token".into(),
+            "updated_at".into(),
+            "user_agent".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -1064,19 +1063,19 @@ impl crate::types::paginate::Pagination for ApiCallWithPriceResultsPage {
 
 impl tabled::Tabled for ApiCallWithPriceResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -1114,33 +1113,33 @@ impl std::fmt::Display for ApiToken {
 
 impl tabled::Tabled for ApiToken {
     const LENGTH: usize = 6;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.is_valid),
-            format!("{:?}", self.token),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.is_valid).into(),
+            format!("{:?}", self.token).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "created_at".to_string(),
-            "id".to_string(),
-            "is_valid".to_string(),
-            "token".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "created_at".into(),
+            "id".into(),
+            "is_valid".into(),
+            "token".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -1196,19 +1195,19 @@ impl crate::types::paginate::Pagination for ApiTokenResultsPage {
 
 impl tabled::Tabled for ApiTokenResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -1234,16 +1233,16 @@ impl std::fmt::Display for AppClientInfo {
 
 impl tabled::Tabled for AppClientInfo {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![if let Some(url) = &self.url {
-            format!("{:?}", url)
+            format!("{:?}", url).into()
         } else {
-            String::new()
+            String::new().into()
         }]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["url".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["url".into()]
     }
 }
 
@@ -1298,65 +1297,65 @@ impl std::fmt::Display for AsyncApiCall {
 
 impl tabled::Tabled for AsyncApiCall {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.type_),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.type_).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(worker) = &self.worker {
-                format!("{:?}", worker)
+                format!("{:?}", worker).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "output".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "type_".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
-            "worker".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "output".into(),
+            "started_at".into(),
+            "status".into(),
+            "type_".into(),
+            "updated_at".into(),
+            "user_id".into(),
+            "worker".into(),
         ]
     }
 }
@@ -1432,19 +1431,19 @@ impl crate::types::paginate::Pagination for AsyncApiCallResultsPage {
 
 impl tabled::Tabled for AsyncApiCallResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -1505,28 +1504,24 @@ impl std::fmt::Display for BillingInfo {
 
 impl tabled::Tabled for BillingInfo {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(address) = &self.address {
-                format!("{:?}", address)
+                format!("{:?}", address).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.phone),
+            format!("{:?}", self.phone).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "address".to_string(),
-            "name".to_string(),
-            "phone".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["address".into(), "name".into(), "phone".into()]
     }
 }
 
@@ -1551,12 +1546,12 @@ impl std::fmt::Display for CacheMetadata {
 
 impl tabled::Tabled for CacheMetadata {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.ok)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![format!("{:?}", self.ok).into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["ok".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["ok".into()]
     }
 }
 
@@ -1604,61 +1599,61 @@ impl std::fmt::Display for CardDetails {
 
 impl tabled::Tabled for CardDetails {
     const LENGTH: usize = 8;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(brand) = &self.brand {
-                format!("{:?}", brand)
+                format!("{:?}", brand).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(checks) = &self.checks {
-                format!("{:?}", checks)
+                format!("{:?}", checks).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(country) = &self.country {
-                format!("{:?}", country)
+                format!("{:?}", country).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(exp_month) = &self.exp_month {
-                format!("{:?}", exp_month)
+                format!("{:?}", exp_month).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(exp_year) = &self.exp_year {
-                format!("{:?}", exp_year)
+                format!("{:?}", exp_year).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(fingerprint) = &self.fingerprint {
-                format!("{:?}", fingerprint)
+                format!("{:?}", fingerprint).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(funding) = &self.funding {
-                format!("{:?}", funding)
+                format!("{:?}", funding).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(last_4) = &self.last_4 {
-                format!("{:?}", last_4)
+                format!("{:?}", last_4).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "brand".to_string(),
-            "checks".to_string(),
-            "country".to_string(),
-            "exp_month".to_string(),
-            "exp_year".to_string(),
-            "fingerprint".to_string(),
-            "funding".to_string(),
-            "last_4".to_string(),
+            "brand".into(),
+            "checks".into(),
+            "country".into(),
+            "exp_month".into(),
+            "exp_year".into(),
+            "fingerprint".into(),
+            "funding".into(),
+            "last_4".into(),
         ]
     }
 }
@@ -1700,49 +1695,49 @@ impl std::fmt::Display for Cluster {
 
 impl tabled::Tabled for Cluster {
     const LENGTH: usize = 6;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(addr) = &self.addr {
-                format!("{:?}", addr)
+                format!("{:?}", addr).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(auth_timeout) = &self.auth_timeout {
-                format!("{:?}", auth_timeout)
+                format!("{:?}", auth_timeout).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cluster_port) = &self.cluster_port {
-                format!("{:?}", cluster_port)
+                format!("{:?}", cluster_port).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(tls_timeout) = &self.tls_timeout {
-                format!("{:?}", tls_timeout)
+                format!("{:?}", tls_timeout).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(urls) = &self.urls {
-                format!("{:?}", urls)
+                format!("{:?}", urls).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "addr".to_string(),
-            "auth_timeout".to_string(),
-            "cluster_port".to_string(),
-            "name".to_string(),
-            "tls_timeout".to_string(),
-            "urls".to_string(),
+            "addr".into(),
+            "auth_timeout".into(),
+            "cluster_port".into(),
+            "name".into(),
+            "tls_timeout".into(),
+            "urls".into(),
         ]
     }
 }
@@ -1804,32 +1799,28 @@ impl std::fmt::Display for CodeOutput {
 
 impl tabled::Tabled for CodeOutput {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(output_files) = &self.output_files {
-                format!("{:?}", output_files)
+                format!("{:?}", output_files).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(stderr) = &self.stderr {
-                format!("{:?}", stderr)
+                format!("{:?}", stderr).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(stdout) = &self.stdout {
-                format!("{:?}", stdout)
+                format!("{:?}", stdout).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "output_files".to_string(),
-            "stderr".to_string(),
-            "stdout".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["output_files".into(), "stderr".into(), "stdout".into()]
     }
 }
 
@@ -1859,23 +1850,23 @@ impl std::fmt::Display for Commit {
 
 impl tabled::Tabled for Commit {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(expected) = &self.expected {
-                format!("{:?}", expected)
+                format!("{:?}", expected).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["expected".to_string(), "id".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["expected".into(), "id".into()]
     }
 }
 
@@ -2030,269 +2021,269 @@ impl std::fmt::Display for Connection {
 
 impl tabled::Tabled for Connection {
     const LENGTH: usize = 46;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(auth_timeout) = &self.auth_timeout {
-                format!("{:?}", auth_timeout)
+                format!("{:?}", auth_timeout).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cluster) = &self.cluster {
-                format!("{:?}", cluster)
+                format!("{:?}", cluster).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.config_load_time),
+            format!("{:?}", self.config_load_time).into(),
             if let Some(connections) = &self.connections {
-                format!("{:?}", connections)
+                format!("{:?}", connections).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cores) = &self.cores {
-                format!("{:?}", cores)
+                format!("{:?}", cores).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cpu) = &self.cpu {
-                format!("{:?}", cpu)
+                format!("{:?}", cpu).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(gateway) = &self.gateway {
-                format!("{:?}", gateway)
+                format!("{:?}", gateway).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(git_commit) = &self.git_commit {
-                format!("{:?}", git_commit)
+                format!("{:?}", git_commit).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(go) = &self.go {
-                format!("{:?}", go)
+                format!("{:?}", go).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(gomaxprocs) = &self.gomaxprocs {
-                format!("{:?}", gomaxprocs)
+                format!("{:?}", gomaxprocs).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.host),
+            format!("{:?}", self.host).into(),
             if let Some(http_base_path) = &self.http_base_path {
-                format!("{:?}", http_base_path)
+                format!("{:?}", http_base_path).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(http_host) = &self.http_host {
-                format!("{:?}", http_host)
+                format!("{:?}", http_host).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(http_port) = &self.http_port {
-                format!("{:?}", http_port)
+                format!("{:?}", http_port).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.http_req_stats),
+            format!("{:?}", self.http_req_stats).into(),
             if let Some(https_port) = &self.https_port {
-                format!("{:?}", https_port)
+                format!("{:?}", https_port).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(in_bytes) = &self.in_bytes {
-                format!("{:?}", in_bytes)
+                format!("{:?}", in_bytes).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(in_msgs) = &self.in_msgs {
-                format!("{:?}", in_msgs)
+                format!("{:?}", in_msgs).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(jetstream) = &self.jetstream {
-                format!("{:?}", jetstream)
+                format!("{:?}", jetstream).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(leaf) = &self.leaf {
-                format!("{:?}", leaf)
+                format!("{:?}", leaf).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(leafnodes) = &self.leafnodes {
-                format!("{:?}", leafnodes)
+                format!("{:?}", leafnodes).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(max_connections) = &self.max_connections {
-                format!("{:?}", max_connections)
+                format!("{:?}", max_connections).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(max_control_line) = &self.max_control_line {
-                format!("{:?}", max_control_line)
+                format!("{:?}", max_control_line).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(max_payload) = &self.max_payload {
-                format!("{:?}", max_payload)
+                format!("{:?}", max_payload).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(max_pending) = &self.max_pending {
-                format!("{:?}", max_pending)
+                format!("{:?}", max_pending).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(mem) = &self.mem {
-                format!("{:?}", mem)
+                format!("{:?}", mem).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.now),
+            format!("{:?}", self.now).into(),
             if let Some(out_bytes) = &self.out_bytes {
-                format!("{:?}", out_bytes)
+                format!("{:?}", out_bytes).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(out_msgs) = &self.out_msgs {
-                format!("{:?}", out_msgs)
+                format!("{:?}", out_msgs).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(ping_interval) = &self.ping_interval {
-                format!("{:?}", ping_interval)
+                format!("{:?}", ping_interval).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(ping_max) = &self.ping_max {
-                format!("{:?}", ping_max)
+                format!("{:?}", ping_max).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(port) = &self.port {
-                format!("{:?}", port)
+                format!("{:?}", port).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(proto) = &self.proto {
-                format!("{:?}", proto)
+                format!("{:?}", proto).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(remotes) = &self.remotes {
-                format!("{:?}", remotes)
+                format!("{:?}", remotes).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(routes) = &self.routes {
-                format!("{:?}", routes)
+                format!("{:?}", routes).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(server_id) = &self.server_id {
-                format!("{:?}", server_id)
+                format!("{:?}", server_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(server_name) = &self.server_name {
-                format!("{:?}", server_name)
+                format!("{:?}", server_name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(slow_consumers) = &self.slow_consumers {
-                format!("{:?}", slow_consumers)
+                format!("{:?}", slow_consumers).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.start),
+            format!("{:?}", self.start).into(),
             if let Some(subscriptions) = &self.subscriptions {
-                format!("{:?}", subscriptions)
+                format!("{:?}", subscriptions).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(system_account) = &self.system_account {
-                format!("{:?}", system_account)
+                format!("{:?}", system_account).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(tls_timeout) = &self.tls_timeout {
-                format!("{:?}", tls_timeout)
+                format!("{:?}", tls_timeout).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(total_connections) = &self.total_connections {
-                format!("{:?}", total_connections)
+                format!("{:?}", total_connections).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(uptime) = &self.uptime {
-                format!("{:?}", uptime)
+                format!("{:?}", uptime).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(version) = &self.version {
-                format!("{:?}", version)
+                format!("{:?}", version).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(write_deadline) = &self.write_deadline {
-                format!("{:?}", write_deadline)
+                format!("{:?}", write_deadline).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "auth_timeout".to_string(),
-            "cluster".to_string(),
-            "config_load_time".to_string(),
-            "connections".to_string(),
-            "cores".to_string(),
-            "cpu".to_string(),
-            "gateway".to_string(),
-            "git_commit".to_string(),
-            "go".to_string(),
-            "gomaxprocs".to_string(),
-            "host".to_string(),
-            "http_base_path".to_string(),
-            "http_host".to_string(),
-            "http_port".to_string(),
-            "http_req_stats".to_string(),
-            "https_port".to_string(),
-            "in_bytes".to_string(),
-            "in_msgs".to_string(),
-            "jetstream".to_string(),
-            "leaf".to_string(),
-            "leafnodes".to_string(),
-            "max_connections".to_string(),
-            "max_control_line".to_string(),
-            "max_payload".to_string(),
-            "max_pending".to_string(),
-            "mem".to_string(),
-            "now".to_string(),
-            "out_bytes".to_string(),
-            "out_msgs".to_string(),
-            "ping_interval".to_string(),
-            "ping_max".to_string(),
-            "port".to_string(),
-            "proto".to_string(),
-            "remotes".to_string(),
-            "routes".to_string(),
-            "server_id".to_string(),
-            "server_name".to_string(),
-            "slow_consumers".to_string(),
-            "start".to_string(),
-            "subscriptions".to_string(),
-            "system_account".to_string(),
-            "tls_timeout".to_string(),
-            "total_connections".to_string(),
-            "uptime".to_string(),
-            "version".to_string(),
-            "write_deadline".to_string(),
+            "auth_timeout".into(),
+            "cluster".into(),
+            "config_load_time".into(),
+            "connections".into(),
+            "cores".into(),
+            "cpu".into(),
+            "gateway".into(),
+            "git_commit".into(),
+            "go".into(),
+            "gomaxprocs".into(),
+            "host".into(),
+            "http_base_path".into(),
+            "http_host".into(),
+            "http_port".into(),
+            "http_req_stats".into(),
+            "https_port".into(),
+            "in_bytes".into(),
+            "in_msgs".into(),
+            "jetstream".into(),
+            "leaf".into(),
+            "leafnodes".into(),
+            "max_connections".into(),
+            "max_control_line".into(),
+            "max_payload".into(),
+            "max_pending".into(),
+            "mem".into(),
+            "now".into(),
+            "out_bytes".into(),
+            "out_msgs".into(),
+            "ping_interval".into(),
+            "ping_max".into(),
+            "port".into(),
+            "proto".into(),
+            "remotes".into(),
+            "routes".into(),
+            "server_id".into(),
+            "server_name".into(),
+            "slow_consumers".into(),
+            "start".into(),
+            "subscriptions".into(),
+            "system_account".into(),
+            "tls_timeout".into(),
+            "total_connections".into(),
+            "uptime".into(),
+            "version".into(),
+            "write_deadline".into(),
         ]
     }
 }
@@ -3967,65 +3958,65 @@ impl std::fmt::Display for Customer {
 
 impl tabled::Tabled for Customer {
     const LENGTH: usize = 10;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(address) = &self.address {
-                format!("{:?}", address)
+                format!("{:?}", address).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(balance) = &self.balance {
-                format!("{:?}", balance)
+                format!("{:?}", balance).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(currency) = &self.currency {
-                format!("{:?}", currency)
+                format!("{:?}", currency).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(delinquent) = &self.delinquent {
-                format!("{:?}", delinquent)
+                format!("{:?}", delinquent).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(email) = &self.email {
-                format!("{:?}", email)
+                format!("{:?}", email).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(metadata) = &self.metadata {
-                format!("{:?}", metadata)
+                format!("{:?}", metadata).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.phone),
+            format!("{:?}", self.phone).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "address".to_string(),
-            "balance".to_string(),
-            "created_at".to_string(),
-            "currency".to_string(),
-            "delinquent".to_string(),
-            "email".to_string(),
-            "id".to_string(),
-            "metadata".to_string(),
-            "name".to_string(),
-            "phone".to_string(),
+            "address".into(),
+            "balance".into(),
+            "created_at".into(),
+            "currency".into(),
+            "delinquent".into(),
+            "email".into(),
+            "id".into(),
+            "metadata".into(),
+            "name".into(),
+            "phone".into(),
         ]
     }
 }
@@ -4080,33 +4071,33 @@ impl std::fmt::Display for CustomerBalance {
 
 impl tabled::Tabled for CustomerBalance {
     const LENGTH: usize = 8;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.created_at),
-            format!("{:?}", self.id),
-            format!("{:?}", self.monthly_credits_remaining),
-            format!("{:?}", self.pre_pay_cash_remaining),
-            format!("{:?}", self.pre_pay_credits_remaining),
-            format!("{:?}", self.total_due),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.created_at).into(),
+            format!("{:?}", self.id).into(),
+            format!("{:?}", self.monthly_credits_remaining).into(),
+            format!("{:?}", self.pre_pay_cash_remaining).into(),
+            format!("{:?}", self.pre_pay_credits_remaining).into(),
+            format!("{:?}", self.total_due).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "created_at".to_string(),
-            "id".to_string(),
-            "monthly_credits_remaining".to_string(),
-            "pre_pay_cash_remaining".to_string(),
-            "pre_pay_credits_remaining".to_string(),
-            "total_due".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "created_at".into(),
+            "id".into(),
+            "monthly_credits_remaining".into(),
+            "pre_pay_cash_remaining".into(),
+            "pre_pay_credits_remaining".into(),
+            "total_due".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -4136,19 +4127,19 @@ impl std::fmt::Display for DeviceAccessTokenRequestForm {
 
 impl tabled::Tabled for DeviceAccessTokenRequestForm {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.client_id),
-            format!("{:?}", self.device_code),
-            format!("{:?}", self.grant_type),
+            format!("{:?}", self.client_id).into(),
+            format!("{:?}", self.device_code).into(),
+            format!("{:?}", self.grant_type).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "client_id".to_string(),
-            "device_code".to_string(),
-            "grant_type".to_string(),
+            "client_id".into(),
+            "device_code".into(),
+            "grant_type".into(),
         ]
     }
 }
@@ -4174,12 +4165,12 @@ impl std::fmt::Display for DeviceAuthRequestForm {
 
 impl tabled::Tabled for DeviceAuthRequestForm {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.client_id)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![format!("{:?}", self.client_id).into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["client_id".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["client_id".into()]
     }
 }
 
@@ -4205,12 +4196,12 @@ impl std::fmt::Display for DeviceAuthVerifyParams {
 
 impl tabled::Tabled for DeviceAuthVerifyParams {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![self.user_code.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![self.user_code.clone().into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["user_code".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["user_code".into()]
     }
 }
 
@@ -4464,373 +4455,373 @@ impl std::fmt::Display for DockerSystemInfo {
 
 impl tabled::Tabled for DockerSystemInfo {
     const LENGTH: usize = 60;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(architecture) = &self.architecture {
-                format!("{:?}", architecture)
+                format!("{:?}", architecture).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(bridge_nf_ip_6tables) = &self.bridge_nf_ip_6tables {
-                format!("{:?}", bridge_nf_ip_6tables)
+                format!("{:?}", bridge_nf_ip_6tables).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(bridge_nf_iptables) = &self.bridge_nf_iptables {
-                format!("{:?}", bridge_nf_iptables)
+                format!("{:?}", bridge_nf_iptables).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cgroup_driver) = &self.cgroup_driver {
-                format!("{:?}", cgroup_driver)
+                format!("{:?}", cgroup_driver).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cgroup_version) = &self.cgroup_version {
-                format!("{:?}", cgroup_version)
+                format!("{:?}", cgroup_version).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cluster_advertise) = &self.cluster_advertise {
-                format!("{:?}", cluster_advertise)
+                format!("{:?}", cluster_advertise).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cluster_store) = &self.cluster_store {
-                format!("{:?}", cluster_store)
+                format!("{:?}", cluster_store).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(containerd_commit) = &self.containerd_commit {
-                format!("{:?}", containerd_commit)
+                format!("{:?}", containerd_commit).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(containers) = &self.containers {
-                format!("{:?}", containers)
+                format!("{:?}", containers).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(containers_paused) = &self.containers_paused {
-                format!("{:?}", containers_paused)
+                format!("{:?}", containers_paused).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(containers_running) = &self.containers_running {
-                format!("{:?}", containers_running)
+                format!("{:?}", containers_running).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(containers_stopped) = &self.containers_stopped {
-                format!("{:?}", containers_stopped)
+                format!("{:?}", containers_stopped).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cpu_cfs_period) = &self.cpu_cfs_period {
-                format!("{:?}", cpu_cfs_period)
+                format!("{:?}", cpu_cfs_period).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cpu_cfs_quota) = &self.cpu_cfs_quota {
-                format!("{:?}", cpu_cfs_quota)
+                format!("{:?}", cpu_cfs_quota).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cpu_set) = &self.cpu_set {
-                format!("{:?}", cpu_set)
+                format!("{:?}", cpu_set).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cpu_shares) = &self.cpu_shares {
-                format!("{:?}", cpu_shares)
+                format!("{:?}", cpu_shares).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(debug) = &self.debug {
-                format!("{:?}", debug)
+                format!("{:?}", debug).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(default_address_pools) = &self.default_address_pools {
-                format!("{:?}", default_address_pools)
+                format!("{:?}", default_address_pools).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(default_runtime) = &self.default_runtime {
-                format!("{:?}", default_runtime)
+                format!("{:?}", default_runtime).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(docker_root_dir) = &self.docker_root_dir {
-                format!("{:?}", docker_root_dir)
+                format!("{:?}", docker_root_dir).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(driver) = &self.driver {
-                format!("{:?}", driver)
+                format!("{:?}", driver).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(driver_status) = &self.driver_status {
-                format!("{:?}", driver_status)
+                format!("{:?}", driver_status).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(experimental_build) = &self.experimental_build {
-                format!("{:?}", experimental_build)
+                format!("{:?}", experimental_build).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(http_proxy) = &self.http_proxy {
-                format!("{:?}", http_proxy)
+                format!("{:?}", http_proxy).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(https_proxy) = &self.https_proxy {
-                format!("{:?}", https_proxy)
+                format!("{:?}", https_proxy).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(images) = &self.images {
-                format!("{:?}", images)
+                format!("{:?}", images).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(index_server_address) = &self.index_server_address {
-                format!("{:?}", index_server_address)
+                format!("{:?}", index_server_address).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(init_binary) = &self.init_binary {
-                format!("{:?}", init_binary)
+                format!("{:?}", init_binary).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(init_commit) = &self.init_commit {
-                format!("{:?}", init_commit)
+                format!("{:?}", init_commit).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(ipv_4_forwarding) = &self.ipv_4_forwarding {
-                format!("{:?}", ipv_4_forwarding)
+                format!("{:?}", ipv_4_forwarding).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(isolation) = &self.isolation {
-                format!("{:?}", isolation)
+                format!("{:?}", isolation).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(kernel_memory) = &self.kernel_memory {
-                format!("{:?}", kernel_memory)
+                format!("{:?}", kernel_memory).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(kernel_memory_tcp) = &self.kernel_memory_tcp {
-                format!("{:?}", kernel_memory_tcp)
+                format!("{:?}", kernel_memory_tcp).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(kernel_version) = &self.kernel_version {
-                format!("{:?}", kernel_version)
+                format!("{:?}", kernel_version).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(labels) = &self.labels {
-                format!("{:?}", labels)
+                format!("{:?}", labels).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(live_restore_enabled) = &self.live_restore_enabled {
-                format!("{:?}", live_restore_enabled)
+                format!("{:?}", live_restore_enabled).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(logging_driver) = &self.logging_driver {
-                format!("{:?}", logging_driver)
+                format!("{:?}", logging_driver).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(mem_total) = &self.mem_total {
-                format!("{:?}", mem_total)
+                format!("{:?}", mem_total).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(memory_limit) = &self.memory_limit {
-                format!("{:?}", memory_limit)
+                format!("{:?}", memory_limit).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(n_events_listener) = &self.n_events_listener {
-                format!("{:?}", n_events_listener)
+                format!("{:?}", n_events_listener).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(n_fd) = &self.n_fd {
-                format!("{:?}", n_fd)
+                format!("{:?}", n_fd).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(ncpu) = &self.ncpu {
-                format!("{:?}", ncpu)
+                format!("{:?}", ncpu).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(no_proxy) = &self.no_proxy {
-                format!("{:?}", no_proxy)
+                format!("{:?}", no_proxy).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(oom_kill_disable) = &self.oom_kill_disable {
-                format!("{:?}", oom_kill_disable)
+                format!("{:?}", oom_kill_disable).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(operating_system) = &self.operating_system {
-                format!("{:?}", operating_system)
+                format!("{:?}", operating_system).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(os_type) = &self.os_type {
-                format!("{:?}", os_type)
+                format!("{:?}", os_type).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(os_version) = &self.os_version {
-                format!("{:?}", os_version)
+                format!("{:?}", os_version).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(pids_limit) = &self.pids_limit {
-                format!("{:?}", pids_limit)
+                format!("{:?}", pids_limit).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(plugins) = &self.plugins {
-                format!("{:?}", plugins)
+                format!("{:?}", plugins).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(product_license) = &self.product_license {
-                format!("{:?}", product_license)
+                format!("{:?}", product_license).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(registry_config) = &self.registry_config {
-                format!("{:?}", registry_config)
+                format!("{:?}", registry_config).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(runc_commit) = &self.runc_commit {
-                format!("{:?}", runc_commit)
+                format!("{:?}", runc_commit).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(runtimes) = &self.runtimes {
-                format!("{:?}", runtimes)
+                format!("{:?}", runtimes).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(security_options) = &self.security_options {
-                format!("{:?}", security_options)
+                format!("{:?}", security_options).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(server_version) = &self.server_version {
-                format!("{:?}", server_version)
+                format!("{:?}", server_version).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(swap_limit) = &self.swap_limit {
-                format!("{:?}", swap_limit)
+                format!("{:?}", swap_limit).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(system_time) = &self.system_time {
-                format!("{:?}", system_time)
+                format!("{:?}", system_time).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(warnings) = &self.warnings {
-                format!("{:?}", warnings)
+                format!("{:?}", warnings).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "architecture".to_string(),
-            "bridge_nf_ip_6tables".to_string(),
-            "bridge_nf_iptables".to_string(),
-            "cgroup_driver".to_string(),
-            "cgroup_version".to_string(),
-            "cluster_advertise".to_string(),
-            "cluster_store".to_string(),
-            "containerd_commit".to_string(),
-            "containers".to_string(),
-            "containers_paused".to_string(),
-            "containers_running".to_string(),
-            "containers_stopped".to_string(),
-            "cpu_cfs_period".to_string(),
-            "cpu_cfs_quota".to_string(),
-            "cpu_set".to_string(),
-            "cpu_shares".to_string(),
-            "debug".to_string(),
-            "default_address_pools".to_string(),
-            "default_runtime".to_string(),
-            "docker_root_dir".to_string(),
-            "driver".to_string(),
-            "driver_status".to_string(),
-            "experimental_build".to_string(),
-            "http_proxy".to_string(),
-            "https_proxy".to_string(),
-            "id".to_string(),
-            "images".to_string(),
-            "index_server_address".to_string(),
-            "init_binary".to_string(),
-            "init_commit".to_string(),
-            "ipv_4_forwarding".to_string(),
-            "isolation".to_string(),
-            "kernel_memory".to_string(),
-            "kernel_memory_tcp".to_string(),
-            "kernel_version".to_string(),
-            "labels".to_string(),
-            "live_restore_enabled".to_string(),
-            "logging_driver".to_string(),
-            "mem_total".to_string(),
-            "memory_limit".to_string(),
-            "n_events_listener".to_string(),
-            "n_fd".to_string(),
-            "name".to_string(),
-            "ncpu".to_string(),
-            "no_proxy".to_string(),
-            "oom_kill_disable".to_string(),
-            "operating_system".to_string(),
-            "os_type".to_string(),
-            "os_version".to_string(),
-            "pids_limit".to_string(),
-            "plugins".to_string(),
-            "product_license".to_string(),
-            "registry_config".to_string(),
-            "runc_commit".to_string(),
-            "runtimes".to_string(),
-            "security_options".to_string(),
-            "server_version".to_string(),
-            "swap_limit".to_string(),
-            "system_time".to_string(),
-            "warnings".to_string(),
+            "architecture".into(),
+            "bridge_nf_ip_6tables".into(),
+            "bridge_nf_iptables".into(),
+            "cgroup_driver".into(),
+            "cgroup_version".into(),
+            "cluster_advertise".into(),
+            "cluster_store".into(),
+            "containerd_commit".into(),
+            "containers".into(),
+            "containers_paused".into(),
+            "containers_running".into(),
+            "containers_stopped".into(),
+            "cpu_cfs_period".into(),
+            "cpu_cfs_quota".into(),
+            "cpu_set".into(),
+            "cpu_shares".into(),
+            "debug".into(),
+            "default_address_pools".into(),
+            "default_runtime".into(),
+            "docker_root_dir".into(),
+            "driver".into(),
+            "driver_status".into(),
+            "experimental_build".into(),
+            "http_proxy".into(),
+            "https_proxy".into(),
+            "id".into(),
+            "images".into(),
+            "index_server_address".into(),
+            "init_binary".into(),
+            "init_commit".into(),
+            "ipv_4_forwarding".into(),
+            "isolation".into(),
+            "kernel_memory".into(),
+            "kernel_memory_tcp".into(),
+            "kernel_version".into(),
+            "labels".into(),
+            "live_restore_enabled".into(),
+            "logging_driver".into(),
+            "mem_total".into(),
+            "memory_limit".into(),
+            "n_events_listener".into(),
+            "n_fd".into(),
+            "name".into(),
+            "ncpu".into(),
+            "no_proxy".into(),
+            "oom_kill_disable".into(),
+            "operating_system".into(),
+            "os_type".into(),
+            "os_version".into(),
+            "pids_limit".into(),
+            "plugins".into(),
+            "product_license".into(),
+            "registry_config".into(),
+            "runc_commit".into(),
+            "runtimes".into(),
+            "security_options".into(),
+            "server_version".into(),
+            "swap_limit".into(),
+            "system_time".into(),
+            "warnings".into(),
         ]
     }
 }
@@ -4859,19 +4850,19 @@ impl std::fmt::Display for EmailAuthenticationForm {
 
 impl tabled::Tabled for EmailAuthenticationForm {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(callback_url) = &self.callback_url {
-                format!("{:?}", callback_url)
+                format!("{:?}", callback_url).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.email.clone(),
+            self.email.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["callback_url".to_string(), "email".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["callback_url".into(), "email".into()]
     }
 }
 
@@ -4907,25 +4898,25 @@ impl std::fmt::Display for EngineMetadata {
 
 impl tabled::Tabled for EngineMetadata {
     const LENGTH: usize = 6;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.async_jobs_running),
-            format!("{:?}", self.cache),
-            format!("{:?}", self.environment),
-            format!("{:?}", self.fs),
-            self.git_hash.clone(),
-            format!("{:?}", self.pubsub),
+            format!("{:?}", self.async_jobs_running).into(),
+            format!("{:?}", self.cache).into(),
+            format!("{:?}", self.environment).into(),
+            format!("{:?}", self.fs).into(),
+            self.git_hash.clone().into(),
+            format!("{:?}", self.pubsub).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "async_jobs_running".to_string(),
-            "cache".to_string(),
-            "environment".to_string(),
-            "fs".to_string(),
-            "git_hash".to_string(),
-            "pubsub".to_string(),
+            "async_jobs_running".into(),
+            "cache".into(),
+            "environment".into(),
+            "fs".into(),
+            "git_hash".into(),
+            "pubsub".into(),
         ]
     }
 }
@@ -4983,24 +4974,20 @@ impl std::fmt::Display for Error {
 
 impl tabled::Tabled for Error {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(error_code) = &self.error_code {
-                format!("{:?}", error_code)
+                format!("{:?}", error_code).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.message.clone(),
-            self.request_id.clone(),
+            self.message.clone().into(),
+            self.request_id.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "error_code".to_string(),
-            "message".to_string(),
-            "request_id".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["error_code".into(), "message".into(), "request_id".into()]
     }
 }
 
@@ -5030,19 +5017,19 @@ impl std::fmt::Display for ExecutorMetadata {
 
 impl tabled::Tabled for ExecutorMetadata {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.docker_info),
-            format!("{:?}", self.environment),
-            self.git_hash.clone(),
+            format!("{:?}", self.docker_info).into(),
+            format!("{:?}", self.environment).into(),
+            self.git_hash.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "docker_info".to_string(),
-            "environment".to_string(),
-            "git_hash".to_string(),
+            "docker_info".into(),
+            "environment".into(),
+            "git_hash".into(),
         ]
     }
 }
@@ -5115,93 +5102,93 @@ impl std::fmt::Display for ExtendedUser {
 
 impl tabled::Tabled for ExtendedUser {
     const LENGTH: usize = 16;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(company) = &self.company {
-                format!("{:?}", company)
+                format!("{:?}", company).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(discord) = &self.discord {
-                format!("{:?}", discord)
+                format!("{:?}", discord).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(email) = &self.email {
-                format!("{:?}", email)
+                format!("{:?}", email).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(email_verified) = &self.email_verified {
-                format!("{:?}", email_verified)
+                format!("{:?}", email_verified).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(first_name) = &self.first_name {
-                format!("{:?}", first_name)
+                format!("{:?}", first_name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(front_id) = &self.front_id {
-                format!("{:?}", front_id)
+                format!("{:?}", front_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(github) = &self.github {
-                format!("{:?}", github)
+                format!("{:?}", github).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.image.clone(),
+            self.image.clone().into(),
             if let Some(last_name) = &self.last_name {
-                format!("{:?}", last_name)
+                format!("{:?}", last_name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(mailchimp_id) = &self.mailchimp_id {
-                format!("{:?}", mailchimp_id)
+                format!("{:?}", mailchimp_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.phone),
+            format!("{:?}", self.phone).into(),
             if let Some(stripe_id) = &self.stripe_id {
-                format!("{:?}", stripe_id)
+                format!("{:?}", stripe_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.updated_at).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "company".to_string(),
-            "created_at".to_string(),
-            "discord".to_string(),
-            "email".to_string(),
-            "email_verified".to_string(),
-            "first_name".to_string(),
-            "front_id".to_string(),
-            "github".to_string(),
-            "id".to_string(),
-            "image".to_string(),
-            "last_name".to_string(),
-            "mailchimp_id".to_string(),
-            "name".to_string(),
-            "phone".to_string(),
-            "stripe_id".to_string(),
-            "updated_at".to_string(),
+            "company".into(),
+            "created_at".into(),
+            "discord".into(),
+            "email".into(),
+            "email_verified".into(),
+            "first_name".into(),
+            "front_id".into(),
+            "github".into(),
+            "id".into(),
+            "image".into(),
+            "last_name".into(),
+            "mailchimp_id".into(),
+            "name".into(),
+            "phone".into(),
+            "stripe_id".into(),
+            "updated_at".into(),
         ]
     }
 }
@@ -5257,19 +5244,19 @@ impl crate::types::paginate::Pagination for ExtendedUserResultsPage {
 
 impl tabled::Tabled for ExtendedUserResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -5296,12 +5283,15 @@ impl std::fmt::Display for Extrude {
 
 impl tabled::Tabled for Extrude {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.distance), format!("{:?}", self.target)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            format!("{:?}", self.distance).into(),
+            format!("{:?}", self.target).into(),
+        ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["distance".to_string(), "target".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["distance".into(), "target".into()]
     }
 }
 
@@ -5349,53 +5339,53 @@ impl std::fmt::Display for FileCenterOfMass {
 
 impl tabled::Tabled for FileCenterOfMass {
     const LENGTH: usize = 10;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(center_of_mass) = &self.center_of_mass {
-                format!("{:?}", center_of_mass)
+                format!("{:?}", center_of_mass).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
-            format!("{:?}", self.src_format),
+            format!("{:?}", self.id).into(),
+            format!("{:?}", self.src_format).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "center_of_mass".to_string(),
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "src_format".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "center_of_mass".into(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "src_format".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -5446,55 +5436,55 @@ impl std::fmt::Display for FileConversion {
 
 impl tabled::Tabled for FileConversion {
     const LENGTH: usize = 11;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_format),
-            format!("{:?}", self.src_format),
+            format!("{:?}", self.output_format).into(),
+            format!("{:?}", self.src_format).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "output".to_string(),
-            "output_format".to_string(),
-            "src_format".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "output".into(),
+            "output_format".into(),
+            "src_format".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -5546,59 +5536,59 @@ impl std::fmt::Display for FileDensity {
 
 impl tabled::Tabled for FileDensity {
     const LENGTH: usize = 11;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(density) = &self.density {
-                format!("{:?}", density)
+                format!("{:?}", density).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(material_mass) = &self.material_mass {
-                format!("{:?}", material_mass)
+                format!("{:?}", material_mass).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.src_format),
+            format!("{:?}", self.src_format).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "density".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "material_mass".to_string(),
-            "src_format".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "density".into(),
+            "error".into(),
+            "id".into(),
+            "material_mass".into(),
+            "src_format".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -5750,59 +5740,59 @@ impl std::fmt::Display for FileMass {
 
 impl tabled::Tabled for FileMass {
     const LENGTH: usize = 11;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(mass) = &self.mass {
-                format!("{:?}", mass)
+                format!("{:?}", mass).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(material_density) = &self.material_density {
-                format!("{:?}", material_density)
+                format!("{:?}", material_density).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.src_format),
+            format!("{:?}", self.src_format).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "mass".to_string(),
-            "material_density".to_string(),
-            "src_format".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "mass".into(),
+            "material_density".into(),
+            "src_format".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -5851,53 +5841,53 @@ impl std::fmt::Display for FileSurfaceArea {
 
 impl tabled::Tabled for FileSurfaceArea {
     const LENGTH: usize = 10;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
-            format!("{:?}", self.src_format),
+            format!("{:?}", self.id).into(),
+            format!("{:?}", self.src_format).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
+            format!("{:?}", self.status).into(),
             if let Some(surface_area) = &self.surface_area {
-                format!("{:?}", surface_area)
+                format!("{:?}", surface_area).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "src_format".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "surface_area".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "src_format".into(),
+            "started_at".into(),
+            "status".into(),
+            "surface_area".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -5924,12 +5914,12 @@ impl std::fmt::Display for FileSystemMetadata {
 
 impl tabled::Tabled for FileSystemMetadata {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.ok)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![format!("{:?}", self.ok).into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["ok".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["ok".into()]
     }
 }
 
@@ -5977,53 +5967,53 @@ impl std::fmt::Display for FileVolume {
 
 impl tabled::Tabled for FileVolume {
     const LENGTH: usize = 10;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
-            format!("{:?}", self.src_format),
+            format!("{:?}", self.id).into(),
+            format!("{:?}", self.src_format).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(volume) = &self.volume {
-                format!("{:?}", volume)
+                format!("{:?}", volume).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "src_format".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
-            "volume".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "src_format".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
+            "volume".into(),
         ]
     }
 }
@@ -6062,43 +6052,43 @@ impl std::fmt::Display for Gateway {
 
 impl tabled::Tabled for Gateway {
     const LENGTH: usize = 5;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(auth_timeout) = &self.auth_timeout {
-                format!("{:?}", auth_timeout)
+                format!("{:?}", auth_timeout).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(host) = &self.host {
-                format!("{:?}", host)
+                format!("{:?}", host).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(port) = &self.port {
-                format!("{:?}", port)
+                format!("{:?}", port).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(tls_timeout) = &self.tls_timeout {
-                format!("{:?}", tls_timeout)
+                format!("{:?}", tls_timeout).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "auth_timeout".to_string(),
-            "host".to_string(),
-            "name".to_string(),
-            "port".to_string(),
-            "tls_timeout".to_string(),
+            "auth_timeout".into(),
+            "host".into(),
+            "name".into(),
+            "port".into(),
+            "tls_timeout".into(),
         ]
     }
 }
@@ -6163,37 +6153,37 @@ impl std::fmt::Display for IndexInfo {
 
 impl tabled::Tabled for IndexInfo {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(mirrors) = &self.mirrors {
-                format!("{:?}", mirrors)
+                format!("{:?}", mirrors).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(official) = &self.official {
-                format!("{:?}", official)
+                format!("{:?}", official).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(secure) = &self.secure {
-                format!("{:?}", secure)
+                format!("{:?}", secure).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "mirrors".to_string(),
-            "name".to_string(),
-            "official".to_string(),
-            "secure".to_string(),
+            "mirrors".into(),
+            "name".into(),
+            "official".into(),
+            "secure".into(),
         ]
     }
 }
@@ -6309,153 +6299,153 @@ impl std::fmt::Display for Invoice {
 
 impl tabled::Tabled for Invoice {
     const LENGTH: usize = 24;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(amount_due) = &self.amount_due {
-                format!("{:?}", amount_due)
+                format!("{:?}", amount_due).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(amount_paid) = &self.amount_paid {
-                format!("{:?}", amount_paid)
+                format!("{:?}", amount_paid).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(amount_remaining) = &self.amount_remaining {
-                format!("{:?}", amount_remaining)
+                format!("{:?}", amount_remaining).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(attempt_count) = &self.attempt_count {
-                format!("{:?}", attempt_count)
+                format!("{:?}", attempt_count).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(attempted) = &self.attempted {
-                format!("{:?}", attempted)
+                format!("{:?}", attempted).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(currency) = &self.currency {
-                format!("{:?}", currency)
+                format!("{:?}", currency).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(customer_email) = &self.customer_email {
-                format!("{:?}", customer_email)
+                format!("{:?}", customer_email).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(customer_id) = &self.customer_id {
-                format!("{:?}", customer_id)
+                format!("{:?}", customer_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(default_payment_method) = &self.default_payment_method {
-                format!("{:?}", default_payment_method)
+                format!("{:?}", default_payment_method).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(description) = &self.description {
-                format!("{:?}", description)
+                format!("{:?}", description).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(lines) = &self.lines {
-                format!("{:?}", lines)
+                format!("{:?}", lines).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(metadata) = &self.metadata {
-                format!("{:?}", metadata)
+                format!("{:?}", metadata).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(number) = &self.number {
-                format!("{:?}", number)
+                format!("{:?}", number).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(paid) = &self.paid {
-                format!("{:?}", paid)
+                format!("{:?}", paid).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(pdf) = &self.pdf {
-                format!("{:?}", pdf)
+                format!("{:?}", pdf).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(receipt_number) = &self.receipt_number {
-                format!("{:?}", receipt_number)
+                format!("{:?}", receipt_number).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(statement_descriptor) = &self.statement_descriptor {
-                format!("{:?}", statement_descriptor)
+                format!("{:?}", statement_descriptor).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(status) = &self.status {
-                format!("{:?}", status)
+                format!("{:?}", status).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(subtotal) = &self.subtotal {
-                format!("{:?}", subtotal)
+                format!("{:?}", subtotal).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(tax) = &self.tax {
-                format!("{:?}", tax)
+                format!("{:?}", tax).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(total) = &self.total {
-                format!("{:?}", total)
+                format!("{:?}", total).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(url) = &self.url {
-                format!("{:?}", url)
+                format!("{:?}", url).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "amount_due".to_string(),
-            "amount_paid".to_string(),
-            "amount_remaining".to_string(),
-            "attempt_count".to_string(),
-            "attempted".to_string(),
-            "created_at".to_string(),
-            "currency".to_string(),
-            "customer_email".to_string(),
-            "customer_id".to_string(),
-            "default_payment_method".to_string(),
-            "description".to_string(),
-            "id".to_string(),
-            "lines".to_string(),
-            "metadata".to_string(),
-            "number".to_string(),
-            "paid".to_string(),
-            "pdf".to_string(),
-            "receipt_number".to_string(),
-            "statement_descriptor".to_string(),
-            "status".to_string(),
-            "subtotal".to_string(),
-            "tax".to_string(),
-            "total".to_string(),
-            "url".to_string(),
+            "amount_due".into(),
+            "amount_paid".into(),
+            "amount_remaining".into(),
+            "attempt_count".into(),
+            "attempted".into(),
+            "created_at".into(),
+            "currency".into(),
+            "customer_email".into(),
+            "customer_id".into(),
+            "default_payment_method".into(),
+            "description".into(),
+            "id".into(),
+            "lines".into(),
+            "metadata".into(),
+            "number".into(),
+            "paid".into(),
+            "pdf".into(),
+            "receipt_number".into(),
+            "statement_descriptor".into(),
+            "status".into(),
+            "subtotal".into(),
+            "tax".into(),
+            "total".into(),
+            "url".into(),
         ]
     }
 }
@@ -6499,49 +6489,49 @@ impl std::fmt::Display for InvoiceLineItem {
 
 impl tabled::Tabled for InvoiceLineItem {
     const LENGTH: usize = 6;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(amount) = &self.amount {
-                format!("{:?}", amount)
+                format!("{:?}", amount).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(currency) = &self.currency {
-                format!("{:?}", currency)
+                format!("{:?}", currency).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(description) = &self.description {
-                format!("{:?}", description)
+                format!("{:?}", description).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(invoice_item) = &self.invoice_item {
-                format!("{:?}", invoice_item)
+                format!("{:?}", invoice_item).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(metadata) = &self.metadata {
-                format!("{:?}", metadata)
+                format!("{:?}", metadata).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "amount".to_string(),
-            "currency".to_string(),
-            "description".to_string(),
-            "id".to_string(),
-            "invoice_item".to_string(),
-            "metadata".to_string(),
+            "amount".into(),
+            "currency".into(),
+            "description".into(),
+            "id".into(),
+            "invoice_item".into(),
+            "metadata".into(),
         ]
     }
 }
@@ -6615,32 +6605,28 @@ impl std::fmt::Display for Jetstream {
 
 impl tabled::Tabled for Jetstream {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(config) = &self.config {
-                format!("{:?}", config)
+                format!("{:?}", config).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(meta) = &self.meta {
-                format!("{:?}", meta)
+                format!("{:?}", meta).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(stats) = &self.stats {
-                format!("{:?}", stats)
+                format!("{:?}", stats).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "config".to_string(),
-            "meta".to_string(),
-            "stats".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["config".into(), "meta".into(), "stats".into()]
     }
 }
 
@@ -6672,32 +6658,28 @@ impl std::fmt::Display for JetstreamApiStats {
 
 impl tabled::Tabled for JetstreamApiStats {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(errors) = &self.errors {
-                format!("{:?}", errors)
+                format!("{:?}", errors).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(inflight) = &self.inflight {
-                format!("{:?}", inflight)
+                format!("{:?}", inflight).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(total) = &self.total {
-                format!("{:?}", total)
+                format!("{:?}", total).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "errors".to_string(),
-            "inflight".to_string(),
-            "total".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["errors".into(), "inflight".into(), "total".into()]
     }
 }
 
@@ -6732,37 +6714,37 @@ impl std::fmt::Display for JetstreamConfig {
 
 impl tabled::Tabled for JetstreamConfig {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(domain) = &self.domain {
-                format!("{:?}", domain)
+                format!("{:?}", domain).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(max_memory) = &self.max_memory {
-                format!("{:?}", max_memory)
+                format!("{:?}", max_memory).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(max_storage) = &self.max_storage {
-                format!("{:?}", max_storage)
+                format!("{:?}", max_storage).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(store_dir) = &self.store_dir {
-                format!("{:?}", store_dir)
+                format!("{:?}", store_dir).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "domain".to_string(),
-            "max_memory".to_string(),
-            "max_storage".to_string(),
-            "store_dir".to_string(),
+            "domain".into(),
+            "max_memory".into(),
+            "max_storage".into(),
+            "store_dir".into(),
         ]
     }
 }
@@ -6807,55 +6789,55 @@ impl std::fmt::Display for JetstreamStats {
 
 impl tabled::Tabled for JetstreamStats {
     const LENGTH: usize = 7;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(accounts) = &self.accounts {
-                format!("{:?}", accounts)
+                format!("{:?}", accounts).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(api) = &self.api {
-                format!("{:?}", api)
+                format!("{:?}", api).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(ha_assets) = &self.ha_assets {
-                format!("{:?}", ha_assets)
+                format!("{:?}", ha_assets).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(memory) = &self.memory {
-                format!("{:?}", memory)
+                format!("{:?}", memory).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(reserved_memory) = &self.reserved_memory {
-                format!("{:?}", reserved_memory)
+                format!("{:?}", reserved_memory).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(reserved_store) = &self.reserved_store {
-                format!("{:?}", reserved_store)
+                format!("{:?}", reserved_store).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(store) = &self.store {
-                format!("{:?}", store)
+                format!("{:?}", store).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "accounts".to_string(),
-            "api".to_string(),
-            "ha_assets".to_string(),
-            "memory".to_string(),
-            "reserved_memory".to_string(),
-            "reserved_store".to_string(),
-            "store".to_string(),
+            "accounts".into(),
+            "api".into(),
+            "ha_assets".into(),
+            "memory".into(),
+            "reserved_memory".into(),
+            "reserved_store".into(),
+            "store".into(),
         ]
     }
 }
@@ -6891,37 +6873,37 @@ impl std::fmt::Display for LeafNode {
 
 impl tabled::Tabled for LeafNode {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(auth_timeout) = &self.auth_timeout {
-                format!("{:?}", auth_timeout)
+                format!("{:?}", auth_timeout).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(host) = &self.host {
-                format!("{:?}", host)
+                format!("{:?}", host).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(port) = &self.port {
-                format!("{:?}", port)
+                format!("{:?}", port).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(tls_timeout) = &self.tls_timeout {
-                format!("{:?}", tls_timeout)
+                format!("{:?}", tls_timeout).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "auth_timeout".to_string(),
-            "host".to_string(),
-            "port".to_string(),
-            "tls_timeout".to_string(),
+            "auth_timeout".into(),
+            "host".into(),
+            "port".into(),
+            "tls_timeout".into(),
         ]
     }
 }
@@ -6949,12 +6931,15 @@ impl std::fmt::Display for Line3D {
 
 impl tabled::Tabled for Line3D {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.from), format!("{:?}", self.to)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            format!("{:?}", self.from).into(),
+            format!("{:?}", self.to).into(),
+        ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["from".to_string(), "to".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["from".into(), "to".into()]
     }
 }
 
@@ -6977,12 +6962,12 @@ impl std::fmt::Display for Mesh {
 
 impl tabled::Tabled for Mesh {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![self.mesh.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![self.mesh.clone().into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["mesh".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["mesh".into()]
     }
 }
 
@@ -7014,32 +6999,28 @@ impl std::fmt::Display for MetaClusterInfo {
 
 impl tabled::Tabled for MetaClusterInfo {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(cluster_size) = &self.cluster_size {
-                format!("{:?}", cluster_size)
+                format!("{:?}", cluster_size).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(leader) = &self.leader {
-                format!("{:?}", leader)
+                format!("{:?}", leader).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "cluster_size".to_string(),
-            "leader".to_string(),
-            "name".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["cluster_size".into(), "leader".into(), "name".into()]
     }
 }
 
@@ -7079,29 +7060,29 @@ impl std::fmt::Display for Metadata {
 
 impl tabled::Tabled for Metadata {
     const LENGTH: usize = 8;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.cache),
-            format!("{:?}", self.engine),
-            format!("{:?}", self.environment),
-            format!("{:?}", self.executor),
-            format!("{:?}", self.fs),
-            self.git_hash.clone(),
-            format!("{:?}", self.point_e),
-            format!("{:?}", self.pubsub),
+            format!("{:?}", self.cache).into(),
+            format!("{:?}", self.engine).into(),
+            format!("{:?}", self.environment).into(),
+            format!("{:?}", self.executor).into(),
+            format!("{:?}", self.fs).into(),
+            self.git_hash.clone().into(),
+            format!("{:?}", self.point_e).into(),
+            format!("{:?}", self.pubsub).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "cache".to_string(),
-            "engine".to_string(),
-            "environment".to_string(),
-            "executor".to_string(),
-            "fs".to_string(),
-            "git_hash".to_string(),
-            "point_e".to_string(),
-            "pubsub".to_string(),
+            "cache".into(),
+            "engine".into(),
+            "environment".into(),
+            "executor".into(),
+            "fs".into(),
+            "git_hash".into(),
+            "point_e".into(),
+            "pubsub".into(),
         ]
     }
 }
@@ -7212,20 +7193,16 @@ impl std::fmt::Display for ModelingCmdReq {
 
 impl tabled::Tabled for ModelingCmdReq {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.cmd),
-            format!("{:?}", self.cmd_id),
-            self.file_id.clone(),
+            format!("{:?}", self.cmd).into(),
+            format!("{:?}", self.cmd_id).into(),
+            self.file_id.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "cmd".to_string(),
-            "cmd_id".to_string(),
-            "file_id".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["cmd".into(), "cmd_id".into(), "file_id".into()]
     }
 }
 
@@ -7252,12 +7229,15 @@ impl std::fmt::Display for ModelingCmdReqBatch {
 
 impl tabled::Tabled for ModelingCmdReqBatch {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.cmds), self.file_id.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            format!("{:?}", self.cmds).into(),
+            self.file_id.clone().into(),
+        ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["cmds".to_string(), "file_id".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["cmds".into(), "file_id".into()]
     }
 }
 
@@ -7288,21 +7268,21 @@ impl std::fmt::Display for ModelingError {
 
 impl tabled::Tabled for ModelingError {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.error_code.clone(),
-            self.external_message.clone(),
-            self.internal_message.clone(),
-            format!("{:?}", self.status_code),
+            self.error_code.clone().into(),
+            self.external_message.clone().into(),
+            self.internal_message.clone().into(),
+            format!("{:?}", self.status_code).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "error_code".to_string(),
-            "external_message".to_string(),
-            "internal_message".to_string(),
-            "status_code".to_string(),
+            "error_code".into(),
+            "external_message".into(),
+            "internal_message".into(),
+            "status_code".into(),
         ]
     }
 }
@@ -7349,12 +7329,12 @@ impl std::fmt::Display for ModelingOutcomes {
 
 impl tabled::Tabled for ModelingOutcomes {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.outcomes)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![format!("{:?}", self.outcomes).into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["outcomes".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["outcomes".into()]
     }
 }
 
@@ -7398,51 +7378,51 @@ impl std::fmt::Display for NewAddress {
 
 impl tabled::Tabled for NewAddress {
     const LENGTH: usize = 7;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(city) = &self.city {
-                format!("{:?}", city)
+                format!("{:?}", city).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.country),
+            format!("{:?}", self.country).into(),
             if let Some(state) = &self.state {
-                format!("{:?}", state)
+                format!("{:?}", state).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(street_1) = &self.street_1 {
-                format!("{:?}", street_1)
+                format!("{:?}", street_1).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(street_2) = &self.street_2 {
-                format!("{:?}", street_2)
+                format!("{:?}", street_2).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(zip) = &self.zip {
-                format!("{:?}", zip)
+                format!("{:?}", zip).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "city".to_string(),
-            "country".to_string(),
-            "state".to_string(),
-            "street_1".to_string(),
-            "street_2".to_string(),
-            "user_id".to_string(),
-            "zip".to_string(),
+            "city".into(),
+            "country".into(),
+            "state".into(),
+            "street_1".into(),
+            "street_2".into(),
+            "user_id".into(),
+            "zip".into(),
         ]
     }
 }
@@ -7479,31 +7459,31 @@ impl std::fmt::Display for Oauth2ClientInfo {
 
 impl tabled::Tabled for Oauth2ClientInfo {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(csrf_token) = &self.csrf_token {
-                format!("{:?}", csrf_token)
+                format!("{:?}", csrf_token).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(pkce_code_verifier) = &self.pkce_code_verifier {
-                format!("{:?}", pkce_code_verifier)
+                format!("{:?}", pkce_code_verifier).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(url) = &self.url {
-                format!("{:?}", url)
+                format!("{:?}", url).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "csrf_token".to_string(),
-            "pkce_code_verifier".to_string(),
-            "url".to_string(),
+            "csrf_token".into(),
+            "pkce_code_verifier".into(),
+            "url".into(),
         ]
     }
 }
@@ -7562,33 +7542,33 @@ impl std::fmt::Display for Onboarding {
 
 impl tabled::Tabled for Onboarding {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(first_call_from_their_machine_date) =
                 &self.first_call_from_their_machine_date
             {
-                format!("{:?}", first_call_from_their_machine_date)
+                format!("{:?}", first_call_from_their_machine_date).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(first_litterbox_execute_date) = &self.first_litterbox_execute_date {
-                format!("{:?}", first_litterbox_execute_date)
+                format!("{:?}", first_litterbox_execute_date).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(first_token_date) = &self.first_token_date {
-                format!("{:?}", first_token_date)
+                format!("{:?}", first_token_date).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "first_call_from_their_machine_date".to_string(),
-            "first_litterbox_execute_date".to_string(),
-            "first_token_date".to_string(),
+            "first_call_from_their_machine_date".into(),
+            "first_litterbox_execute_date".into(),
+            "first_token_date".into(),
         ]
     }
 }
@@ -7619,23 +7599,23 @@ impl std::fmt::Display for OutputFile {
 
 impl tabled::Tabled for OutputFile {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(contents) = &self.contents {
-                format!("{:?}", contents)
+                format!("{:?}", contents).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["contents".to_string(), "name".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["contents".into(), "name".into()]
     }
 }
 
@@ -7663,12 +7643,12 @@ impl std::fmt::Display for PaymentIntent {
 
 impl tabled::Tabled for PaymentIntent {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![self.client_secret.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![self.client_secret.clone().into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["client_secret".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["client_secret".into()]
     }
 }
 
@@ -7708,37 +7688,37 @@ impl std::fmt::Display for PaymentMethod {
 
 impl tabled::Tabled for PaymentMethod {
     const LENGTH: usize = 6;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.billing_info),
+            format!("{:?}", self.billing_info).into(),
             if let Some(card) = &self.card {
-                format!("{:?}", card)
+                format!("{:?}", card).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(metadata) = &self.metadata {
-                format!("{:?}", metadata)
+                format!("{:?}", metadata).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.type_),
+            format!("{:?}", self.type_).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "billing_info".to_string(),
-            "card".to_string(),
-            "created_at".to_string(),
-            "id".to_string(),
-            "metadata".to_string(),
-            "type_".to_string(),
+            "billing_info".into(),
+            "card".into(),
+            "created_at".into(),
+            "id".into(),
+            "metadata".into(),
+            "type_".into(),
         ]
     }
 }
@@ -7778,31 +7758,31 @@ impl std::fmt::Display for PaymentMethodCardChecks {
 
 impl tabled::Tabled for PaymentMethodCardChecks {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(address_line_1_check) = &self.address_line_1_check {
-                format!("{:?}", address_line_1_check)
+                format!("{:?}", address_line_1_check).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(address_postal_code_check) = &self.address_postal_code_check {
-                format!("{:?}", address_postal_code_check)
+                format!("{:?}", address_postal_code_check).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cvc_check) = &self.cvc_check {
-                format!("{:?}", cvc_check)
+                format!("{:?}", cvc_check).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "address_line_1_check".to_string(),
-            "address_postal_code_check".to_string(),
-            "cvc_check".to_string(),
+            "address_line_1_check".into(),
+            "address_postal_code_check".into(),
+            "cvc_check".into(),
         ]
     }
 }
@@ -7876,53 +7856,53 @@ impl std::fmt::Display for PhysicsConstant {
 
 impl tabled::Tabled for PhysicsConstant {
     const LENGTH: usize = 10;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.constant),
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.constant).into(),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(value) = &self.value {
-                format!("{:?}", value)
+                format!("{:?}", value).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "constant".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
-            "value".to_string(),
+            "completed_at".into(),
+            "constant".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
+            "value".into(),
         ]
     }
 }
@@ -8103,37 +8083,37 @@ impl std::fmt::Display for PluginsInfo {
 
 impl tabled::Tabled for PluginsInfo {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(authorization) = &self.authorization {
-                format!("{:?}", authorization)
+                format!("{:?}", authorization).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(log) = &self.log {
-                format!("{:?}", log)
+                format!("{:?}", log).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(network) = &self.network {
-                format!("{:?}", network)
+                format!("{:?}", network).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(volume) = &self.volume {
-                format!("{:?}", volume)
+                format!("{:?}", volume).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "authorization".to_string(),
-            "log".to_string(),
-            "network".to_string(),
-            "volume".to_string(),
+            "authorization".into(),
+            "log".into(),
+            "network".into(),
+            "volume".into(),
         ]
     }
 }
@@ -8159,12 +8139,15 @@ impl std::fmt::Display for Point2D {
 
 impl tabled::Tabled for Point2D {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.x), format!("{:?}", self.y)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            format!("{:?}", self.x).into(),
+            format!("{:?}", self.y).into(),
+        ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["x".to_string(), "y".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["x".into(), "y".into()]
     }
 }
 
@@ -8190,16 +8173,16 @@ impl std::fmt::Display for Point3D {
 
 impl tabled::Tabled for Point3D {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.x),
-            format!("{:?}", self.y),
-            format!("{:?}", self.z),
+            format!("{:?}", self.x).into(),
+            format!("{:?}", self.y).into(),
+            format!("{:?}", self.z).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["x".to_string(), "y".to_string(), "z".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["x".into(), "y".into(), "z".into()]
     }
 }
 
@@ -8225,12 +8208,12 @@ impl std::fmt::Display for PointEMetadata {
 
 impl tabled::Tabled for PointEMetadata {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.ok)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![format!("{:?}", self.ok).into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["ok".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["ok".into()]
     }
 }
 
@@ -8255,12 +8238,12 @@ impl std::fmt::Display for Pong {
 
 impl tabled::Tabled for Pong {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![self.message.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![self.message.clone().into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["message".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["message".into()]
     }
 }
 
@@ -8308,47 +8291,47 @@ impl std::fmt::Display for RegistryServiceConfig {
 
 impl tabled::Tabled for RegistryServiceConfig {
     const LENGTH: usize = 5;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(allow_nondistributable_artifacts_cid_rs) =
                 &self.allow_nondistributable_artifacts_cid_rs
             {
-                format!("{:?}", allow_nondistributable_artifacts_cid_rs)
+                format!("{:?}", allow_nondistributable_artifacts_cid_rs).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(allow_nondistributable_artifacts_hostnames) =
                 &self.allow_nondistributable_artifacts_hostnames
             {
-                format!("{:?}", allow_nondistributable_artifacts_hostnames)
+                format!("{:?}", allow_nondistributable_artifacts_hostnames).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(index_configs) = &self.index_configs {
-                format!("{:?}", index_configs)
+                format!("{:?}", index_configs).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(insecure_registry_cid_rs) = &self.insecure_registry_cid_rs {
-                format!("{:?}", insecure_registry_cid_rs)
+                format!("{:?}", insecure_registry_cid_rs).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(mirrors) = &self.mirrors {
-                format!("{:?}", mirrors)
+                format!("{:?}", mirrors).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "allow_nondistributable_artifacts_cid_rs".to_string(),
-            "allow_nondistributable_artifacts_hostnames".to_string(),
-            "index_configs".to_string(),
-            "insecure_registry_cid_rs".to_string(),
-            "mirrors".to_string(),
+            "allow_nondistributable_artifacts_cid_rs".into(),
+            "allow_nondistributable_artifacts_hostnames".into(),
+            "index_configs".into(),
+            "insecure_registry_cid_rs".into(),
+            "mirrors".into(),
         ]
     }
 }
@@ -8381,23 +8364,23 @@ impl std::fmt::Display for Runtime {
 
 impl tabled::Tabled for Runtime {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(path) = &self.path {
-                format!("{:?}", path)
+                format!("{:?}", path).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(runtime_args) = &self.runtime_args {
-                format!("{:?}", runtime_args)
+                format!("{:?}", runtime_args).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["path".to_string(), "runtime_args".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["path".into(), "runtime_args".into()]
     }
 }
 
@@ -8434,33 +8417,33 @@ impl std::fmt::Display for Session {
 
 impl tabled::Tabled for Session {
     const LENGTH: usize = 6;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.created_at),
-            format!("{:?}", self.expires),
+            format!("{:?}", self.created_at).into(),
+            format!("{:?}", self.expires).into(),
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.session_token),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.session_token).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "created_at".to_string(),
-            "expires".to_string(),
-            "id".to_string(),
-            "session_token".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "created_at".into(),
+            "expires".into(),
+            "id".into(),
+            "session_token".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -8542,23 +8525,23 @@ impl std::fmt::Display for SystemInfoDefaultAddressPools {
 
 impl tabled::Tabled for SystemInfoDefaultAddressPools {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(base) = &self.base {
-                format!("{:?}", base)
+                format!("{:?}", base).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(size) = &self.size {
-                format!("{:?}", size)
+                format!("{:?}", size).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["base".to_string(), "size".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["base".into(), "size".into()]
     }
 }
 
@@ -8664,61 +8647,61 @@ impl std::fmt::Display for UnitAngleConversion {
 
 impl tabled::Tabled for UnitAngleConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -8845,61 +8828,61 @@ impl std::fmt::Display for UnitAreaConversion {
 
 impl tabled::Tabled for UnitAreaConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -8986,61 +8969,61 @@ impl std::fmt::Display for UnitCurrentConversion {
 
 impl tabled::Tabled for UnitCurrentConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -9135,61 +9118,61 @@ impl std::fmt::Display for UnitEnergyConversion {
 
 impl tabled::Tabled for UnitEnergyConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -9288,61 +9271,61 @@ impl std::fmt::Display for UnitForceConversion {
 
 impl tabled::Tabled for UnitForceConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -9445,61 +9428,61 @@ impl std::fmt::Display for UnitFrequencyConversion {
 
 impl tabled::Tabled for UnitFrequencyConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -9622,61 +9605,61 @@ impl std::fmt::Display for UnitLengthConversion {
 
 impl tabled::Tabled for UnitLengthConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -9807,61 +9790,61 @@ impl std::fmt::Display for UnitMassConversion {
 
 impl tabled::Tabled for UnitMassConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -9960,61 +9943,61 @@ impl std::fmt::Display for UnitPowerConversion {
 
 impl tabled::Tabled for UnitPowerConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -10113,61 +10096,61 @@ impl std::fmt::Display for UnitPressureConversion {
 
 impl tabled::Tabled for UnitPressureConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -10254,61 +10237,61 @@ impl std::fmt::Display for UnitTemperatureConversion {
 
 impl tabled::Tabled for UnitTemperatureConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -10387,61 +10370,61 @@ impl std::fmt::Display for UnitTorqueConversion {
 
 impl tabled::Tabled for UnitTorqueConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -10588,61 +10571,61 @@ impl std::fmt::Display for UnitVolumeConversion {
 
 impl tabled::Tabled for UnitVolumeConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -10684,45 +10667,45 @@ impl std::fmt::Display for UpdateUser {
 
 impl tabled::Tabled for UpdateUser {
     const LENGTH: usize = 6;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(company) = &self.company {
-                format!("{:?}", company)
+                format!("{:?}", company).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(discord) = &self.discord {
-                format!("{:?}", discord)
+                format!("{:?}", discord).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(first_name) = &self.first_name {
-                format!("{:?}", first_name)
+                format!("{:?}", first_name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(github) = &self.github {
-                format!("{:?}", github)
+                format!("{:?}", github).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(last_name) = &self.last_name {
-                format!("{:?}", last_name)
+                format!("{:?}", last_name).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.phone),
+            format!("{:?}", self.phone).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "company".to_string(),
-            "discord".to_string(),
-            "first_name".to_string(),
-            "github".to_string(),
-            "last_name".to_string(),
-            "phone".to_string(),
+            "company".into(),
+            "discord".into(),
+            "first_name".into(),
+            "github".into(),
+            "last_name".into(),
+            "phone".into(),
         ]
     }
 }
@@ -10784,75 +10767,75 @@ impl std::fmt::Display for User {
 
 impl tabled::Tabled for User {
     const LENGTH: usize = 13;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(company) = &self.company {
-                format!("{:?}", company)
+                format!("{:?}", company).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(discord) = &self.discord {
-                format!("{:?}", discord)
+                format!("{:?}", discord).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(email) = &self.email {
-                format!("{:?}", email)
+                format!("{:?}", email).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(email_verified) = &self.email_verified {
-                format!("{:?}", email_verified)
+                format!("{:?}", email_verified).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(first_name) = &self.first_name {
-                format!("{:?}", first_name)
+                format!("{:?}", first_name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(github) = &self.github {
-                format!("{:?}", github)
+                format!("{:?}", github).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.image.clone(),
+            self.image.clone().into(),
             if let Some(last_name) = &self.last_name {
-                format!("{:?}", last_name)
+                format!("{:?}", last_name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.phone),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.phone).into(),
+            format!("{:?}", self.updated_at).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "company".to_string(),
-            "created_at".to_string(),
-            "discord".to_string(),
-            "email".to_string(),
-            "email_verified".to_string(),
-            "first_name".to_string(),
-            "github".to_string(),
-            "id".to_string(),
-            "image".to_string(),
-            "last_name".to_string(),
-            "name".to_string(),
-            "phone".to_string(),
-            "updated_at".to_string(),
+            "company".into(),
+            "created_at".into(),
+            "discord".into(),
+            "email".into(),
+            "email_verified".into(),
+            "first_name".into(),
+            "github".into(),
+            "id".into(),
+            "image".into(),
+            "last_name".into(),
+            "name".into(),
+            "phone".into(),
+            "updated_at".into(),
         ]
     }
 }
@@ -10908,19 +10891,19 @@ impl crate::types::paginate::Pagination for UserResultsPage {
 
 impl tabled::Tabled for UserResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -10958,31 +10941,31 @@ impl std::fmt::Display for VerificationToken {
 
 impl tabled::Tabled for VerificationToken {
     const LENGTH: usize = 5;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.created_at),
-            format!("{:?}", self.expires),
+            format!("{:?}", self.created_at).into(),
+            format!("{:?}", self.expires).into(),
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(identifier) = &self.identifier {
-                format!("{:?}", identifier)
+                format!("{:?}", identifier).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.updated_at).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "created_at".to_string(),
-            "expires".to_string(),
-            "id".to_string(),
-            "identifier".to_string(),
-            "updated_at".to_string(),
+            "created_at".into(),
+            "expires".into(),
+            "id".into(),
+            "identifier".into(),
+            "updated_at".into(),
         ]
     }
 }

--- a/openapitor/src/lib.rs
+++ b/openapitor/src/lib.rs
@@ -588,7 +588,7 @@ schemars = {{ version = "0.8", features = ["bytes", "chrono", "url", "uuid1"] }}
 serde = {{ version = "1", features = ["derive"] }}
 serde_json = "1"
 serde_urlencoded = "^0.7"
-tabled = {{ version = "0.8.0", features = ["color"] }}
+tabled = {{ version = "0.12.0", features = ["color"] }}
 thiserror = "1"
 tokio = {{ version = "1.20.1", features = ["sync"] }}
 tracing = "^0.1"

--- a/openapitor/src/types/mod.rs
+++ b/openapitor/src/types/mod.rs
@@ -674,7 +674,7 @@ impl TypeSpace {
         for (k, v) in &o.properties {
             let prop = clean_property_name(k);
             let prop_ident = format_ident!("{}", prop);
-            headers.push(quote!(#prop.to_string()));
+            headers.push(quote!(#prop.into()));
 
             // Get the schema for the property.
             let inner_schema = if let openapiv3::ReferenceOr::Item(i) = v {
@@ -689,24 +689,24 @@ impl TypeSpace {
             // Check if this type is required.
             if o.required.contains(k) && type_name.is_string()? {
                 fields.push(quote!(
-                    self.#prop_ident.clone()
+                    self.#prop_ident.clone().into()
                 ));
             } else if !o.required.contains(k)
                 && type_name.rendered()? != "phone_number::PhoneNumber"
             {
                 fields.push(quote!(
                     if let Some(#prop_ident) = &self.#prop_ident {
-                        format!("{:?}", #prop_ident)
+                        format!("{:?}", #prop_ident).into()
                     } else {
-                        String::new()
+                        String::new().into()
                     }
                 ));
             } else if type_name.rendered()? == "PhoneNumber" {
                 fields.push(quote!(
-                    self.#prop_ident.to_string()
+                    self.#prop_ident.to_string().into()
                 ));
             } else {
-                fields.push(quote!(format!("{:?}", self.#prop_ident)));
+                fields.push(quote!(format!("{:?}", self.#prop_ident).into()));
             }
         }
 
@@ -714,12 +714,12 @@ impl TypeSpace {
             impl tabled::Tabled for #struct_name {
                 const LENGTH: usize = #length;
 
-                fn fields(&self) -> Vec<String> {
+                fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
                     vec![
                         #(#fields),*
                     ]
                 }
-                fn headers() -> Vec<String> {
+                fn headers() -> Vec<std::borrow::Cow<'static, str>> {
                     vec![
                         #(#headers),*
                     ]

--- a/openapitor/tests/types/kittycad.file-density-date-time-override-output.rs.gen
+++ b/openapitor/tests/types/kittycad.file-density-date-time-override-output.rs.gen
@@ -55,59 +55,59 @@ impl std::fmt::Display for FileDensity {
 
 impl tabled::Tabled for FileDensity {
     const LENGTH: usize = 11;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(density) = &self.density {
-                format!("{:?}", density)
+                format!("{:?}", density).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(material_mass) = &self.material_mass {
-                format!("{:?}", material_mass)
+                format!("{:?}", material_mass).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.src_format),
+            format!("{:?}", self.src_format).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "density".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "material_mass".to_string(),
-            "src_format".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "density".into(),
+            "error".into(),
+            "id".into(),
+            "material_mass".into(),
+            "src_format".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }

--- a/openapitor/tests/types/kittycad.rs.gen
+++ b/openapitor/tests/types/kittycad.rs.gen
@@ -454,28 +454,24 @@ impl std::fmt::Display for AiPluginApi {
 
 impl tabled::Tabled for AiPluginApi {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(is_user_authenticated) = &self.is_user_authenticated {
-                format!("{:?}", is_user_authenticated)
+                format!("{:?}", is_user_authenticated).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(type_) = &self.type_ {
-                format!("{:?}", type_)
+                format!("{:?}", type_).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.url.clone(),
+            self.url.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "is_user_authenticated".to_string(),
-            "type_".to_string(),
-            "url".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["is_user_authenticated".into(), "type_".into(), "url".into()]
     }
 }
 
@@ -531,23 +527,23 @@ impl std::fmt::Display for AiPluginAuth {
 
 impl tabled::Tabled for AiPluginAuth {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(authorization_type) = &self.authorization_type {
-                format!("{:?}", authorization_type)
+                format!("{:?}", authorization_type).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(type_) = &self.type_ {
-                format!("{:?}", type_)
+                format!("{:?}", type_).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["authorization_type".to_string(), "type_".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["authorization_type".into(), "type_".into()]
     }
 }
 
@@ -654,57 +650,57 @@ impl std::fmt::Display for AiPluginManifest {
 
 impl tabled::Tabled for AiPluginManifest {
     const LENGTH: usize = 10;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.api),
-            format!("{:?}", self.auth),
+            format!("{:?}", self.api).into(),
+            format!("{:?}", self.auth).into(),
             if let Some(contact_email) = &self.contact_email {
-                format!("{:?}", contact_email)
+                format!("{:?}", contact_email).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(description_for_human) = &self.description_for_human {
-                format!("{:?}", description_for_human)
+                format!("{:?}", description_for_human).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(description_for_model) = &self.description_for_model {
-                format!("{:?}", description_for_model)
+                format!("{:?}", description_for_model).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.legal_info_url.clone(),
-            self.logo_url.clone(),
+            self.legal_info_url.clone().into(),
+            self.logo_url.clone().into(),
             if let Some(name_for_human) = &self.name_for_human {
-                format!("{:?}", name_for_human)
+                format!("{:?}", name_for_human).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name_for_model) = &self.name_for_model {
-                format!("{:?}", name_for_model)
+                format!("{:?}", name_for_model).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(schema_version) = &self.schema_version {
-                format!("{:?}", schema_version)
+                format!("{:?}", schema_version).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "api".to_string(),
-            "auth".to_string(),
-            "contact_email".to_string(),
-            "description_for_human".to_string(),
-            "description_for_model".to_string(),
-            "legal_info_url".to_string(),
-            "logo_url".to_string(),
-            "name_for_human".to_string(),
-            "name_for_model".to_string(),
-            "schema_version".to_string(),
+            "api".into(),
+            "auth".into(),
+            "contact_email".into(),
+            "description_for_human".into(),
+            "description_for_model".into(),
+            "legal_info_url".into(),
+            "logo_url".into(),
+            "name_for_human".into(),
+            "name_for_model".into(),
+            "schema_version".into(),
         ]
     }
 }
@@ -730,12 +726,15 @@ impl std::fmt::Display for ApiCallQueryGroup {
 
 impl tabled::Tabled for ApiCallQueryGroup {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.count), self.query.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            format!("{:?}", self.count).into(),
+            self.query.clone().into(),
+        ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["count".to_string(), "query".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["count".into(), "query".into()]
     }
 }
 
@@ -888,121 +887,121 @@ impl std::fmt::Display for ApiCallWithPrice {
 
 impl tabled::Tabled for ApiCallWithPrice {
     const LENGTH: usize = 22;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(duration) = &self.duration {
-                format!("{:?}", duration)
+                format!("{:?}", duration).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(email) = &self.email {
-                format!("{:?}", email)
+                format!("{:?}", email).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(endpoint) = &self.endpoint {
-                format!("{:?}", endpoint)
+                format!("{:?}", endpoint).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(ip_address) = &self.ip_address {
-                format!("{:?}", ip_address)
+                format!("{:?}", ip_address).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(litterbox) = &self.litterbox {
-                format!("{:?}", litterbox)
+                format!("{:?}", litterbox).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.method),
+            format!("{:?}", self.method).into(),
             if let Some(minutes) = &self.minutes {
-                format!("{:?}", minutes)
+                format!("{:?}", minutes).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(origin) = &self.origin {
-                format!("{:?}", origin)
+                format!("{:?}", origin).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(price) = &self.price {
-                format!("{:?}", price)
+                format!("{:?}", price).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(request_body) = &self.request_body {
-                format!("{:?}", request_body)
+                format!("{:?}", request_body).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(request_query_params) = &self.request_query_params {
-                format!("{:?}", request_query_params)
+                format!("{:?}", request_query_params).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(response_body) = &self.response_body {
-                format!("{:?}", response_body)
+                format!("{:?}", response_body).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(status_code) = &self.status_code {
-                format!("{:?}", status_code)
+                format!("{:?}", status_code).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(stripe_invoice_item_id) = &self.stripe_invoice_item_id {
-                format!("{:?}", stripe_invoice_item_id)
+                format!("{:?}", stripe_invoice_item_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.token),
-            format!("{:?}", self.updated_at),
-            self.user_agent.clone(),
+            format!("{:?}", self.token).into(),
+            format!("{:?}", self.updated_at).into(),
+            self.user_agent.clone().into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "duration".to_string(),
-            "email".to_string(),
-            "endpoint".to_string(),
-            "id".to_string(),
-            "ip_address".to_string(),
-            "litterbox".to_string(),
-            "method".to_string(),
-            "minutes".to_string(),
-            "origin".to_string(),
-            "price".to_string(),
-            "request_body".to_string(),
-            "request_query_params".to_string(),
-            "response_body".to_string(),
-            "started_at".to_string(),
-            "status_code".to_string(),
-            "stripe_invoice_item_id".to_string(),
-            "token".to_string(),
-            "updated_at".to_string(),
-            "user_agent".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "duration".into(),
+            "email".into(),
+            "endpoint".into(),
+            "id".into(),
+            "ip_address".into(),
+            "litterbox".into(),
+            "method".into(),
+            "minutes".into(),
+            "origin".into(),
+            "price".into(),
+            "request_body".into(),
+            "request_query_params".into(),
+            "response_body".into(),
+            "started_at".into(),
+            "status_code".into(),
+            "stripe_invoice_item_id".into(),
+            "token".into(),
+            "updated_at".into(),
+            "user_agent".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -1058,19 +1057,19 @@ impl crate::types::paginate::Pagination for ApiCallWithPriceResultsPage {
 
 impl tabled::Tabled for ApiCallWithPriceResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -1107,33 +1106,33 @@ impl std::fmt::Display for ApiToken {
 
 impl tabled::Tabled for ApiToken {
     const LENGTH: usize = 6;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.is_valid),
-            format!("{:?}", self.token),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.is_valid).into(),
+            format!("{:?}", self.token).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "created_at".to_string(),
-            "id".to_string(),
-            "is_valid".to_string(),
-            "token".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "created_at".into(),
+            "id".into(),
+            "is_valid".into(),
+            "token".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -1189,19 +1188,19 @@ impl crate::types::paginate::Pagination for ApiTokenResultsPage {
 
 impl tabled::Tabled for ApiTokenResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -1227,16 +1226,16 @@ impl std::fmt::Display for AppClientInfo {
 
 impl tabled::Tabled for AppClientInfo {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![if let Some(url) = &self.url {
-            format!("{:?}", url)
+            format!("{:?}", url).into()
         } else {
-            String::new()
+            String::new().into()
         }]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["url".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["url".into()]
     }
 }
 
@@ -1291,65 +1290,65 @@ impl std::fmt::Display for AsyncApiCall {
 
 impl tabled::Tabled for AsyncApiCall {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.type_),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.type_).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(worker) = &self.worker {
-                format!("{:?}", worker)
+                format!("{:?}", worker).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "output".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "type_".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
-            "worker".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "output".into(),
+            "started_at".into(),
+            "status".into(),
+            "type_".into(),
+            "updated_at".into(),
+            "user_id".into(),
+            "worker".into(),
         ]
     }
 }
@@ -1425,19 +1424,19 @@ impl crate::types::paginate::Pagination for AsyncApiCallResultsPage {
 
 impl tabled::Tabled for AsyncApiCallResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -1498,28 +1497,24 @@ impl std::fmt::Display for BillingInfo {
 
 impl tabled::Tabled for BillingInfo {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(address) = &self.address {
-                format!("{:?}", address)
+                format!("{:?}", address).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.phone),
+            format!("{:?}", self.phone).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "address".to_string(),
-            "name".to_string(),
-            "phone".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["address".into(), "name".into(), "phone".into()]
     }
 }
 
@@ -1544,12 +1539,12 @@ impl std::fmt::Display for CacheMetadata {
 
 impl tabled::Tabled for CacheMetadata {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.ok)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![format!("{:?}", self.ok).into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["ok".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["ok".into()]
     }
 }
 
@@ -1596,61 +1591,61 @@ impl std::fmt::Display for CardDetails {
 
 impl tabled::Tabled for CardDetails {
     const LENGTH: usize = 8;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(brand) = &self.brand {
-                format!("{:?}", brand)
+                format!("{:?}", brand).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(checks) = &self.checks {
-                format!("{:?}", checks)
+                format!("{:?}", checks).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(country) = &self.country {
-                format!("{:?}", country)
+                format!("{:?}", country).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(exp_month) = &self.exp_month {
-                format!("{:?}", exp_month)
+                format!("{:?}", exp_month).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(exp_year) = &self.exp_year {
-                format!("{:?}", exp_year)
+                format!("{:?}", exp_year).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(fingerprint) = &self.fingerprint {
-                format!("{:?}", fingerprint)
+                format!("{:?}", fingerprint).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(funding) = &self.funding {
-                format!("{:?}", funding)
+                format!("{:?}", funding).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(last_4) = &self.last_4 {
-                format!("{:?}", last_4)
+                format!("{:?}", last_4).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "brand".to_string(),
-            "checks".to_string(),
-            "country".to_string(),
-            "exp_month".to_string(),
-            "exp_year".to_string(),
-            "fingerprint".to_string(),
-            "funding".to_string(),
-            "last_4".to_string(),
+            "brand".into(),
+            "checks".into(),
+            "country".into(),
+            "exp_month".into(),
+            "exp_year".into(),
+            "fingerprint".into(),
+            "funding".into(),
+            "last_4".into(),
         ]
     }
 }
@@ -1692,49 +1687,49 @@ impl std::fmt::Display for Cluster {
 
 impl tabled::Tabled for Cluster {
     const LENGTH: usize = 6;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(addr) = &self.addr {
-                format!("{:?}", addr)
+                format!("{:?}", addr).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(auth_timeout) = &self.auth_timeout {
-                format!("{:?}", auth_timeout)
+                format!("{:?}", auth_timeout).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cluster_port) = &self.cluster_port {
-                format!("{:?}", cluster_port)
+                format!("{:?}", cluster_port).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(tls_timeout) = &self.tls_timeout {
-                format!("{:?}", tls_timeout)
+                format!("{:?}", tls_timeout).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(urls) = &self.urls {
-                format!("{:?}", urls)
+                format!("{:?}", urls).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "addr".to_string(),
-            "auth_timeout".to_string(),
-            "cluster_port".to_string(),
-            "name".to_string(),
-            "tls_timeout".to_string(),
-            "urls".to_string(),
+            "addr".into(),
+            "auth_timeout".into(),
+            "cluster_port".into(),
+            "name".into(),
+            "tls_timeout".into(),
+            "urls".into(),
         ]
     }
 }
@@ -1796,32 +1791,28 @@ impl std::fmt::Display for CodeOutput {
 
 impl tabled::Tabled for CodeOutput {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(output_files) = &self.output_files {
-                format!("{:?}", output_files)
+                format!("{:?}", output_files).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(stderr) = &self.stderr {
-                format!("{:?}", stderr)
+                format!("{:?}", stderr).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(stdout) = &self.stdout {
-                format!("{:?}", stdout)
+                format!("{:?}", stdout).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "output_files".to_string(),
-            "stderr".to_string(),
-            "stdout".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["output_files".into(), "stderr".into(), "stdout".into()]
     }
 }
 
@@ -1850,23 +1841,23 @@ impl std::fmt::Display for Commit {
 
 impl tabled::Tabled for Commit {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(expected) = &self.expected {
-                format!("{:?}", expected)
+                format!("{:?}", expected).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["expected".to_string(), "id".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["expected".into(), "id".into()]
     }
 }
 
@@ -2020,269 +2011,269 @@ impl std::fmt::Display for Connection {
 
 impl tabled::Tabled for Connection {
     const LENGTH: usize = 46;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(auth_timeout) = &self.auth_timeout {
-                format!("{:?}", auth_timeout)
+                format!("{:?}", auth_timeout).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cluster) = &self.cluster {
-                format!("{:?}", cluster)
+                format!("{:?}", cluster).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.config_load_time),
+            format!("{:?}", self.config_load_time).into(),
             if let Some(connections) = &self.connections {
-                format!("{:?}", connections)
+                format!("{:?}", connections).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cores) = &self.cores {
-                format!("{:?}", cores)
+                format!("{:?}", cores).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cpu) = &self.cpu {
-                format!("{:?}", cpu)
+                format!("{:?}", cpu).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(gateway) = &self.gateway {
-                format!("{:?}", gateway)
+                format!("{:?}", gateway).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(git_commit) = &self.git_commit {
-                format!("{:?}", git_commit)
+                format!("{:?}", git_commit).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(go) = &self.go {
-                format!("{:?}", go)
+                format!("{:?}", go).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(gomaxprocs) = &self.gomaxprocs {
-                format!("{:?}", gomaxprocs)
+                format!("{:?}", gomaxprocs).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.host),
+            format!("{:?}", self.host).into(),
             if let Some(http_base_path) = &self.http_base_path {
-                format!("{:?}", http_base_path)
+                format!("{:?}", http_base_path).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(http_host) = &self.http_host {
-                format!("{:?}", http_host)
+                format!("{:?}", http_host).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(http_port) = &self.http_port {
-                format!("{:?}", http_port)
+                format!("{:?}", http_port).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.http_req_stats),
+            format!("{:?}", self.http_req_stats).into(),
             if let Some(https_port) = &self.https_port {
-                format!("{:?}", https_port)
+                format!("{:?}", https_port).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(in_bytes) = &self.in_bytes {
-                format!("{:?}", in_bytes)
+                format!("{:?}", in_bytes).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(in_msgs) = &self.in_msgs {
-                format!("{:?}", in_msgs)
+                format!("{:?}", in_msgs).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(jetstream) = &self.jetstream {
-                format!("{:?}", jetstream)
+                format!("{:?}", jetstream).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(leaf) = &self.leaf {
-                format!("{:?}", leaf)
+                format!("{:?}", leaf).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(leafnodes) = &self.leafnodes {
-                format!("{:?}", leafnodes)
+                format!("{:?}", leafnodes).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(max_connections) = &self.max_connections {
-                format!("{:?}", max_connections)
+                format!("{:?}", max_connections).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(max_control_line) = &self.max_control_line {
-                format!("{:?}", max_control_line)
+                format!("{:?}", max_control_line).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(max_payload) = &self.max_payload {
-                format!("{:?}", max_payload)
+                format!("{:?}", max_payload).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(max_pending) = &self.max_pending {
-                format!("{:?}", max_pending)
+                format!("{:?}", max_pending).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(mem) = &self.mem {
-                format!("{:?}", mem)
+                format!("{:?}", mem).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.now),
+            format!("{:?}", self.now).into(),
             if let Some(out_bytes) = &self.out_bytes {
-                format!("{:?}", out_bytes)
+                format!("{:?}", out_bytes).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(out_msgs) = &self.out_msgs {
-                format!("{:?}", out_msgs)
+                format!("{:?}", out_msgs).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(ping_interval) = &self.ping_interval {
-                format!("{:?}", ping_interval)
+                format!("{:?}", ping_interval).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(ping_max) = &self.ping_max {
-                format!("{:?}", ping_max)
+                format!("{:?}", ping_max).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(port) = &self.port {
-                format!("{:?}", port)
+                format!("{:?}", port).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(proto) = &self.proto {
-                format!("{:?}", proto)
+                format!("{:?}", proto).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(remotes) = &self.remotes {
-                format!("{:?}", remotes)
+                format!("{:?}", remotes).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(routes) = &self.routes {
-                format!("{:?}", routes)
+                format!("{:?}", routes).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(server_id) = &self.server_id {
-                format!("{:?}", server_id)
+                format!("{:?}", server_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(server_name) = &self.server_name {
-                format!("{:?}", server_name)
+                format!("{:?}", server_name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(slow_consumers) = &self.slow_consumers {
-                format!("{:?}", slow_consumers)
+                format!("{:?}", slow_consumers).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.start),
+            format!("{:?}", self.start).into(),
             if let Some(subscriptions) = &self.subscriptions {
-                format!("{:?}", subscriptions)
+                format!("{:?}", subscriptions).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(system_account) = &self.system_account {
-                format!("{:?}", system_account)
+                format!("{:?}", system_account).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(tls_timeout) = &self.tls_timeout {
-                format!("{:?}", tls_timeout)
+                format!("{:?}", tls_timeout).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(total_connections) = &self.total_connections {
-                format!("{:?}", total_connections)
+                format!("{:?}", total_connections).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(uptime) = &self.uptime {
-                format!("{:?}", uptime)
+                format!("{:?}", uptime).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(version) = &self.version {
-                format!("{:?}", version)
+                format!("{:?}", version).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(write_deadline) = &self.write_deadline {
-                format!("{:?}", write_deadline)
+                format!("{:?}", write_deadline).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "auth_timeout".to_string(),
-            "cluster".to_string(),
-            "config_load_time".to_string(),
-            "connections".to_string(),
-            "cores".to_string(),
-            "cpu".to_string(),
-            "gateway".to_string(),
-            "git_commit".to_string(),
-            "go".to_string(),
-            "gomaxprocs".to_string(),
-            "host".to_string(),
-            "http_base_path".to_string(),
-            "http_host".to_string(),
-            "http_port".to_string(),
-            "http_req_stats".to_string(),
-            "https_port".to_string(),
-            "in_bytes".to_string(),
-            "in_msgs".to_string(),
-            "jetstream".to_string(),
-            "leaf".to_string(),
-            "leafnodes".to_string(),
-            "max_connections".to_string(),
-            "max_control_line".to_string(),
-            "max_payload".to_string(),
-            "max_pending".to_string(),
-            "mem".to_string(),
-            "now".to_string(),
-            "out_bytes".to_string(),
-            "out_msgs".to_string(),
-            "ping_interval".to_string(),
-            "ping_max".to_string(),
-            "port".to_string(),
-            "proto".to_string(),
-            "remotes".to_string(),
-            "routes".to_string(),
-            "server_id".to_string(),
-            "server_name".to_string(),
-            "slow_consumers".to_string(),
-            "start".to_string(),
-            "subscriptions".to_string(),
-            "system_account".to_string(),
-            "tls_timeout".to_string(),
-            "total_connections".to_string(),
-            "uptime".to_string(),
-            "version".to_string(),
-            "write_deadline".to_string(),
+            "auth_timeout".into(),
+            "cluster".into(),
+            "config_load_time".into(),
+            "connections".into(),
+            "cores".into(),
+            "cpu".into(),
+            "gateway".into(),
+            "git_commit".into(),
+            "go".into(),
+            "gomaxprocs".into(),
+            "host".into(),
+            "http_base_path".into(),
+            "http_host".into(),
+            "http_port".into(),
+            "http_req_stats".into(),
+            "https_port".into(),
+            "in_bytes".into(),
+            "in_msgs".into(),
+            "jetstream".into(),
+            "leaf".into(),
+            "leafnodes".into(),
+            "max_connections".into(),
+            "max_control_line".into(),
+            "max_payload".into(),
+            "max_pending".into(),
+            "mem".into(),
+            "now".into(),
+            "out_bytes".into(),
+            "out_msgs".into(),
+            "ping_interval".into(),
+            "ping_max".into(),
+            "port".into(),
+            "proto".into(),
+            "remotes".into(),
+            "routes".into(),
+            "server_id".into(),
+            "server_name".into(),
+            "slow_consumers".into(),
+            "start".into(),
+            "subscriptions".into(),
+            "system_account".into(),
+            "tls_timeout".into(),
+            "total_connections".into(),
+            "uptime".into(),
+            "version".into(),
+            "write_deadline".into(),
         ]
     }
 }
@@ -3946,65 +3937,65 @@ impl std::fmt::Display for Customer {
 
 impl tabled::Tabled for Customer {
     const LENGTH: usize = 10;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(address) = &self.address {
-                format!("{:?}", address)
+                format!("{:?}", address).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(balance) = &self.balance {
-                format!("{:?}", balance)
+                format!("{:?}", balance).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(currency) = &self.currency {
-                format!("{:?}", currency)
+                format!("{:?}", currency).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(delinquent) = &self.delinquent {
-                format!("{:?}", delinquent)
+                format!("{:?}", delinquent).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(email) = &self.email {
-                format!("{:?}", email)
+                format!("{:?}", email).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(metadata) = &self.metadata {
-                format!("{:?}", metadata)
+                format!("{:?}", metadata).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.phone),
+            format!("{:?}", self.phone).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "address".to_string(),
-            "balance".to_string(),
-            "created_at".to_string(),
-            "currency".to_string(),
-            "delinquent".to_string(),
-            "email".to_string(),
-            "id".to_string(),
-            "metadata".to_string(),
-            "name".to_string(),
-            "phone".to_string(),
+            "address".into(),
+            "balance".into(),
+            "created_at".into(),
+            "currency".into(),
+            "delinquent".into(),
+            "email".into(),
+            "id".into(),
+            "metadata".into(),
+            "name".into(),
+            "phone".into(),
         ]
     }
 }
@@ -4045,33 +4036,33 @@ impl std::fmt::Display for CustomerBalance {
 
 impl tabled::Tabled for CustomerBalance {
     const LENGTH: usize = 8;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.created_at),
-            format!("{:?}", self.id),
-            format!("{:?}", self.monthly_credits_remaining),
-            format!("{:?}", self.pre_pay_cash_remaining),
-            format!("{:?}", self.pre_pay_credits_remaining),
-            format!("{:?}", self.total_due),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.created_at).into(),
+            format!("{:?}", self.id).into(),
+            format!("{:?}", self.monthly_credits_remaining).into(),
+            format!("{:?}", self.pre_pay_cash_remaining).into(),
+            format!("{:?}", self.pre_pay_credits_remaining).into(),
+            format!("{:?}", self.total_due).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "created_at".to_string(),
-            "id".to_string(),
-            "monthly_credits_remaining".to_string(),
-            "pre_pay_cash_remaining".to_string(),
-            "pre_pay_credits_remaining".to_string(),
-            "total_due".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "created_at".into(),
+            "id".into(),
+            "monthly_credits_remaining".into(),
+            "pre_pay_cash_remaining".into(),
+            "pre_pay_credits_remaining".into(),
+            "total_due".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -4101,19 +4092,19 @@ impl std::fmt::Display for DeviceAccessTokenRequestForm {
 
 impl tabled::Tabled for DeviceAccessTokenRequestForm {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.client_id),
-            format!("{:?}", self.device_code),
-            format!("{:?}", self.grant_type),
+            format!("{:?}", self.client_id).into(),
+            format!("{:?}", self.device_code).into(),
+            format!("{:?}", self.grant_type).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "client_id".to_string(),
-            "device_code".to_string(),
-            "grant_type".to_string(),
+            "client_id".into(),
+            "device_code".into(),
+            "grant_type".into(),
         ]
     }
 }
@@ -4139,12 +4130,12 @@ impl std::fmt::Display for DeviceAuthRequestForm {
 
 impl tabled::Tabled for DeviceAuthRequestForm {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.client_id)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![format!("{:?}", self.client_id).into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["client_id".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["client_id".into()]
     }
 }
 
@@ -4169,12 +4160,12 @@ impl std::fmt::Display for DeviceAuthVerifyParams {
 
 impl tabled::Tabled for DeviceAuthVerifyParams {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![self.user_code.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![self.user_code.clone().into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["user_code".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["user_code".into()]
     }
 }
 
@@ -4379,373 +4370,373 @@ impl std::fmt::Display for DockerSystemInfo {
 
 impl tabled::Tabled for DockerSystemInfo {
     const LENGTH: usize = 60;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(architecture) = &self.architecture {
-                format!("{:?}", architecture)
+                format!("{:?}", architecture).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(bridge_nf_ip_6tables) = &self.bridge_nf_ip_6tables {
-                format!("{:?}", bridge_nf_ip_6tables)
+                format!("{:?}", bridge_nf_ip_6tables).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(bridge_nf_iptables) = &self.bridge_nf_iptables {
-                format!("{:?}", bridge_nf_iptables)
+                format!("{:?}", bridge_nf_iptables).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cgroup_driver) = &self.cgroup_driver {
-                format!("{:?}", cgroup_driver)
+                format!("{:?}", cgroup_driver).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cgroup_version) = &self.cgroup_version {
-                format!("{:?}", cgroup_version)
+                format!("{:?}", cgroup_version).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cluster_advertise) = &self.cluster_advertise {
-                format!("{:?}", cluster_advertise)
+                format!("{:?}", cluster_advertise).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cluster_store) = &self.cluster_store {
-                format!("{:?}", cluster_store)
+                format!("{:?}", cluster_store).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(containerd_commit) = &self.containerd_commit {
-                format!("{:?}", containerd_commit)
+                format!("{:?}", containerd_commit).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(containers) = &self.containers {
-                format!("{:?}", containers)
+                format!("{:?}", containers).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(containers_paused) = &self.containers_paused {
-                format!("{:?}", containers_paused)
+                format!("{:?}", containers_paused).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(containers_running) = &self.containers_running {
-                format!("{:?}", containers_running)
+                format!("{:?}", containers_running).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(containers_stopped) = &self.containers_stopped {
-                format!("{:?}", containers_stopped)
+                format!("{:?}", containers_stopped).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cpu_cfs_period) = &self.cpu_cfs_period {
-                format!("{:?}", cpu_cfs_period)
+                format!("{:?}", cpu_cfs_period).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cpu_cfs_quota) = &self.cpu_cfs_quota {
-                format!("{:?}", cpu_cfs_quota)
+                format!("{:?}", cpu_cfs_quota).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cpu_set) = &self.cpu_set {
-                format!("{:?}", cpu_set)
+                format!("{:?}", cpu_set).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cpu_shares) = &self.cpu_shares {
-                format!("{:?}", cpu_shares)
+                format!("{:?}", cpu_shares).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(debug) = &self.debug {
-                format!("{:?}", debug)
+                format!("{:?}", debug).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(default_address_pools) = &self.default_address_pools {
-                format!("{:?}", default_address_pools)
+                format!("{:?}", default_address_pools).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(default_runtime) = &self.default_runtime {
-                format!("{:?}", default_runtime)
+                format!("{:?}", default_runtime).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(docker_root_dir) = &self.docker_root_dir {
-                format!("{:?}", docker_root_dir)
+                format!("{:?}", docker_root_dir).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(driver) = &self.driver {
-                format!("{:?}", driver)
+                format!("{:?}", driver).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(driver_status) = &self.driver_status {
-                format!("{:?}", driver_status)
+                format!("{:?}", driver_status).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(experimental_build) = &self.experimental_build {
-                format!("{:?}", experimental_build)
+                format!("{:?}", experimental_build).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(http_proxy) = &self.http_proxy {
-                format!("{:?}", http_proxy)
+                format!("{:?}", http_proxy).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(https_proxy) = &self.https_proxy {
-                format!("{:?}", https_proxy)
+                format!("{:?}", https_proxy).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(images) = &self.images {
-                format!("{:?}", images)
+                format!("{:?}", images).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(index_server_address) = &self.index_server_address {
-                format!("{:?}", index_server_address)
+                format!("{:?}", index_server_address).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(init_binary) = &self.init_binary {
-                format!("{:?}", init_binary)
+                format!("{:?}", init_binary).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(init_commit) = &self.init_commit {
-                format!("{:?}", init_commit)
+                format!("{:?}", init_commit).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(ipv_4_forwarding) = &self.ipv_4_forwarding {
-                format!("{:?}", ipv_4_forwarding)
+                format!("{:?}", ipv_4_forwarding).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(isolation) = &self.isolation {
-                format!("{:?}", isolation)
+                format!("{:?}", isolation).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(kernel_memory) = &self.kernel_memory {
-                format!("{:?}", kernel_memory)
+                format!("{:?}", kernel_memory).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(kernel_memory_tcp) = &self.kernel_memory_tcp {
-                format!("{:?}", kernel_memory_tcp)
+                format!("{:?}", kernel_memory_tcp).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(kernel_version) = &self.kernel_version {
-                format!("{:?}", kernel_version)
+                format!("{:?}", kernel_version).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(labels) = &self.labels {
-                format!("{:?}", labels)
+                format!("{:?}", labels).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(live_restore_enabled) = &self.live_restore_enabled {
-                format!("{:?}", live_restore_enabled)
+                format!("{:?}", live_restore_enabled).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(logging_driver) = &self.logging_driver {
-                format!("{:?}", logging_driver)
+                format!("{:?}", logging_driver).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(mem_total) = &self.mem_total {
-                format!("{:?}", mem_total)
+                format!("{:?}", mem_total).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(memory_limit) = &self.memory_limit {
-                format!("{:?}", memory_limit)
+                format!("{:?}", memory_limit).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(n_events_listener) = &self.n_events_listener {
-                format!("{:?}", n_events_listener)
+                format!("{:?}", n_events_listener).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(n_fd) = &self.n_fd {
-                format!("{:?}", n_fd)
+                format!("{:?}", n_fd).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(ncpu) = &self.ncpu {
-                format!("{:?}", ncpu)
+                format!("{:?}", ncpu).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(no_proxy) = &self.no_proxy {
-                format!("{:?}", no_proxy)
+                format!("{:?}", no_proxy).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(oom_kill_disable) = &self.oom_kill_disable {
-                format!("{:?}", oom_kill_disable)
+                format!("{:?}", oom_kill_disable).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(operating_system) = &self.operating_system {
-                format!("{:?}", operating_system)
+                format!("{:?}", operating_system).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(os_type) = &self.os_type {
-                format!("{:?}", os_type)
+                format!("{:?}", os_type).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(os_version) = &self.os_version {
-                format!("{:?}", os_version)
+                format!("{:?}", os_version).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(pids_limit) = &self.pids_limit {
-                format!("{:?}", pids_limit)
+                format!("{:?}", pids_limit).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(plugins) = &self.plugins {
-                format!("{:?}", plugins)
+                format!("{:?}", plugins).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(product_license) = &self.product_license {
-                format!("{:?}", product_license)
+                format!("{:?}", product_license).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(registry_config) = &self.registry_config {
-                format!("{:?}", registry_config)
+                format!("{:?}", registry_config).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(runc_commit) = &self.runc_commit {
-                format!("{:?}", runc_commit)
+                format!("{:?}", runc_commit).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(runtimes) = &self.runtimes {
-                format!("{:?}", runtimes)
+                format!("{:?}", runtimes).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(security_options) = &self.security_options {
-                format!("{:?}", security_options)
+                format!("{:?}", security_options).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(server_version) = &self.server_version {
-                format!("{:?}", server_version)
+                format!("{:?}", server_version).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(swap_limit) = &self.swap_limit {
-                format!("{:?}", swap_limit)
+                format!("{:?}", swap_limit).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(system_time) = &self.system_time {
-                format!("{:?}", system_time)
+                format!("{:?}", system_time).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(warnings) = &self.warnings {
-                format!("{:?}", warnings)
+                format!("{:?}", warnings).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "architecture".to_string(),
-            "bridge_nf_ip_6tables".to_string(),
-            "bridge_nf_iptables".to_string(),
-            "cgroup_driver".to_string(),
-            "cgroup_version".to_string(),
-            "cluster_advertise".to_string(),
-            "cluster_store".to_string(),
-            "containerd_commit".to_string(),
-            "containers".to_string(),
-            "containers_paused".to_string(),
-            "containers_running".to_string(),
-            "containers_stopped".to_string(),
-            "cpu_cfs_period".to_string(),
-            "cpu_cfs_quota".to_string(),
-            "cpu_set".to_string(),
-            "cpu_shares".to_string(),
-            "debug".to_string(),
-            "default_address_pools".to_string(),
-            "default_runtime".to_string(),
-            "docker_root_dir".to_string(),
-            "driver".to_string(),
-            "driver_status".to_string(),
-            "experimental_build".to_string(),
-            "http_proxy".to_string(),
-            "https_proxy".to_string(),
-            "id".to_string(),
-            "images".to_string(),
-            "index_server_address".to_string(),
-            "init_binary".to_string(),
-            "init_commit".to_string(),
-            "ipv_4_forwarding".to_string(),
-            "isolation".to_string(),
-            "kernel_memory".to_string(),
-            "kernel_memory_tcp".to_string(),
-            "kernel_version".to_string(),
-            "labels".to_string(),
-            "live_restore_enabled".to_string(),
-            "logging_driver".to_string(),
-            "mem_total".to_string(),
-            "memory_limit".to_string(),
-            "n_events_listener".to_string(),
-            "n_fd".to_string(),
-            "name".to_string(),
-            "ncpu".to_string(),
-            "no_proxy".to_string(),
-            "oom_kill_disable".to_string(),
-            "operating_system".to_string(),
-            "os_type".to_string(),
-            "os_version".to_string(),
-            "pids_limit".to_string(),
-            "plugins".to_string(),
-            "product_license".to_string(),
-            "registry_config".to_string(),
-            "runc_commit".to_string(),
-            "runtimes".to_string(),
-            "security_options".to_string(),
-            "server_version".to_string(),
-            "swap_limit".to_string(),
-            "system_time".to_string(),
-            "warnings".to_string(),
+            "architecture".into(),
+            "bridge_nf_ip_6tables".into(),
+            "bridge_nf_iptables".into(),
+            "cgroup_driver".into(),
+            "cgroup_version".into(),
+            "cluster_advertise".into(),
+            "cluster_store".into(),
+            "containerd_commit".into(),
+            "containers".into(),
+            "containers_paused".into(),
+            "containers_running".into(),
+            "containers_stopped".into(),
+            "cpu_cfs_period".into(),
+            "cpu_cfs_quota".into(),
+            "cpu_set".into(),
+            "cpu_shares".into(),
+            "debug".into(),
+            "default_address_pools".into(),
+            "default_runtime".into(),
+            "docker_root_dir".into(),
+            "driver".into(),
+            "driver_status".into(),
+            "experimental_build".into(),
+            "http_proxy".into(),
+            "https_proxy".into(),
+            "id".into(),
+            "images".into(),
+            "index_server_address".into(),
+            "init_binary".into(),
+            "init_commit".into(),
+            "ipv_4_forwarding".into(),
+            "isolation".into(),
+            "kernel_memory".into(),
+            "kernel_memory_tcp".into(),
+            "kernel_version".into(),
+            "labels".into(),
+            "live_restore_enabled".into(),
+            "logging_driver".into(),
+            "mem_total".into(),
+            "memory_limit".into(),
+            "n_events_listener".into(),
+            "n_fd".into(),
+            "name".into(),
+            "ncpu".into(),
+            "no_proxy".into(),
+            "oom_kill_disable".into(),
+            "operating_system".into(),
+            "os_type".into(),
+            "os_version".into(),
+            "pids_limit".into(),
+            "plugins".into(),
+            "product_license".into(),
+            "registry_config".into(),
+            "runc_commit".into(),
+            "runtimes".into(),
+            "security_options".into(),
+            "server_version".into(),
+            "swap_limit".into(),
+            "system_time".into(),
+            "warnings".into(),
         ]
     }
 }
@@ -4774,19 +4765,19 @@ impl std::fmt::Display for EmailAuthenticationForm {
 
 impl tabled::Tabled for EmailAuthenticationForm {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(callback_url) = &self.callback_url {
-                format!("{:?}", callback_url)
+                format!("{:?}", callback_url).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.email.clone(),
+            self.email.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["callback_url".to_string(), "email".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["callback_url".into(), "email".into()]
     }
 }
 
@@ -4821,25 +4812,25 @@ impl std::fmt::Display for EngineMetadata {
 
 impl tabled::Tabled for EngineMetadata {
     const LENGTH: usize = 6;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.async_jobs_running),
-            format!("{:?}", self.cache),
-            format!("{:?}", self.environment),
-            format!("{:?}", self.fs),
-            self.git_hash.clone(),
-            format!("{:?}", self.pubsub),
+            format!("{:?}", self.async_jobs_running).into(),
+            format!("{:?}", self.cache).into(),
+            format!("{:?}", self.environment).into(),
+            format!("{:?}", self.fs).into(),
+            self.git_hash.clone().into(),
+            format!("{:?}", self.pubsub).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "async_jobs_running".to_string(),
-            "cache".to_string(),
-            "environment".to_string(),
-            "fs".to_string(),
-            "git_hash".to_string(),
-            "pubsub".to_string(),
+            "async_jobs_running".into(),
+            "cache".into(),
+            "environment".into(),
+            "fs".into(),
+            "git_hash".into(),
+            "pubsub".into(),
         ]
     }
 }
@@ -4896,24 +4887,20 @@ impl std::fmt::Display for Error {
 
 impl tabled::Tabled for Error {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(error_code) = &self.error_code {
-                format!("{:?}", error_code)
+                format!("{:?}", error_code).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.message.clone(),
-            self.request_id.clone(),
+            self.message.clone().into(),
+            self.request_id.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "error_code".to_string(),
-            "message".to_string(),
-            "request_id".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["error_code".into(), "message".into(), "request_id".into()]
     }
 }
 
@@ -4942,19 +4929,19 @@ impl std::fmt::Display for ExecutorMetadata {
 
 impl tabled::Tabled for ExecutorMetadata {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.docker_info),
-            format!("{:?}", self.environment),
-            self.git_hash.clone(),
+            format!("{:?}", self.docker_info).into(),
+            format!("{:?}", self.environment).into(),
+            self.git_hash.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "docker_info".to_string(),
-            "environment".to_string(),
-            "git_hash".to_string(),
+            "docker_info".into(),
+            "environment".into(),
+            "git_hash".into(),
         ]
     }
 }
@@ -5023,93 +5010,93 @@ impl std::fmt::Display for ExtendedUser {
 
 impl tabled::Tabled for ExtendedUser {
     const LENGTH: usize = 16;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(company) = &self.company {
-                format!("{:?}", company)
+                format!("{:?}", company).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(discord) = &self.discord {
-                format!("{:?}", discord)
+                format!("{:?}", discord).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(email) = &self.email {
-                format!("{:?}", email)
+                format!("{:?}", email).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(email_verified) = &self.email_verified {
-                format!("{:?}", email_verified)
+                format!("{:?}", email_verified).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(first_name) = &self.first_name {
-                format!("{:?}", first_name)
+                format!("{:?}", first_name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(front_id) = &self.front_id {
-                format!("{:?}", front_id)
+                format!("{:?}", front_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(github) = &self.github {
-                format!("{:?}", github)
+                format!("{:?}", github).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.image.clone(),
+            self.image.clone().into(),
             if let Some(last_name) = &self.last_name {
-                format!("{:?}", last_name)
+                format!("{:?}", last_name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(mailchimp_id) = &self.mailchimp_id {
-                format!("{:?}", mailchimp_id)
+                format!("{:?}", mailchimp_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.phone),
+            format!("{:?}", self.phone).into(),
             if let Some(stripe_id) = &self.stripe_id {
-                format!("{:?}", stripe_id)
+                format!("{:?}", stripe_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.updated_at).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "company".to_string(),
-            "created_at".to_string(),
-            "discord".to_string(),
-            "email".to_string(),
-            "email_verified".to_string(),
-            "first_name".to_string(),
-            "front_id".to_string(),
-            "github".to_string(),
-            "id".to_string(),
-            "image".to_string(),
-            "last_name".to_string(),
-            "mailchimp_id".to_string(),
-            "name".to_string(),
-            "phone".to_string(),
-            "stripe_id".to_string(),
-            "updated_at".to_string(),
+            "company".into(),
+            "created_at".into(),
+            "discord".into(),
+            "email".into(),
+            "email_verified".into(),
+            "first_name".into(),
+            "front_id".into(),
+            "github".into(),
+            "id".into(),
+            "image".into(),
+            "last_name".into(),
+            "mailchimp_id".into(),
+            "name".into(),
+            "phone".into(),
+            "stripe_id".into(),
+            "updated_at".into(),
         ]
     }
 }
@@ -5165,19 +5152,19 @@ impl crate::types::paginate::Pagination for ExtendedUserResultsPage {
 
 impl tabled::Tabled for ExtendedUserResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -5204,12 +5191,15 @@ impl std::fmt::Display for Extrude {
 
 impl tabled::Tabled for Extrude {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.distance), format!("{:?}", self.target)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            format!("{:?}", self.distance).into(),
+            format!("{:?}", self.target).into(),
+        ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["distance".to_string(), "target".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["distance".into(), "target".into()]
     }
 }
 
@@ -5257,53 +5247,53 @@ impl std::fmt::Display for FileCenterOfMass {
 
 impl tabled::Tabled for FileCenterOfMass {
     const LENGTH: usize = 10;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(center_of_mass) = &self.center_of_mass {
-                format!("{:?}", center_of_mass)
+                format!("{:?}", center_of_mass).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
-            format!("{:?}", self.src_format),
+            format!("{:?}", self.id).into(),
+            format!("{:?}", self.src_format).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "center_of_mass".to_string(),
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "src_format".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "center_of_mass".into(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "src_format".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -5354,55 +5344,55 @@ impl std::fmt::Display for FileConversion {
 
 impl tabled::Tabled for FileConversion {
     const LENGTH: usize = 11;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_format),
-            format!("{:?}", self.src_format),
+            format!("{:?}", self.output_format).into(),
+            format!("{:?}", self.src_format).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "output".to_string(),
-            "output_format".to_string(),
-            "src_format".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "output".into(),
+            "output_format".into(),
+            "src_format".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -5454,59 +5444,59 @@ impl std::fmt::Display for FileDensity {
 
 impl tabled::Tabled for FileDensity {
     const LENGTH: usize = 11;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(density) = &self.density {
-                format!("{:?}", density)
+                format!("{:?}", density).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(material_mass) = &self.material_mass {
-                format!("{:?}", material_mass)
+                format!("{:?}", material_mass).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.src_format),
+            format!("{:?}", self.src_format).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "density".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "material_mass".to_string(),
-            "src_format".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "density".into(),
+            "error".into(),
+            "id".into(),
+            "material_mass".into(),
+            "src_format".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -5656,59 +5646,59 @@ impl std::fmt::Display for FileMass {
 
 impl tabled::Tabled for FileMass {
     const LENGTH: usize = 11;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(mass) = &self.mass {
-                format!("{:?}", mass)
+                format!("{:?}", mass).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(material_density) = &self.material_density {
-                format!("{:?}", material_density)
+                format!("{:?}", material_density).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.src_format),
+            format!("{:?}", self.src_format).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "mass".to_string(),
-            "material_density".to_string(),
-            "src_format".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "mass".into(),
+            "material_density".into(),
+            "src_format".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -5757,53 +5747,53 @@ impl std::fmt::Display for FileSurfaceArea {
 
 impl tabled::Tabled for FileSurfaceArea {
     const LENGTH: usize = 10;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
-            format!("{:?}", self.src_format),
+            format!("{:?}", self.id).into(),
+            format!("{:?}", self.src_format).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
+            format!("{:?}", self.status).into(),
             if let Some(surface_area) = &self.surface_area {
-                format!("{:?}", surface_area)
+                format!("{:?}", surface_area).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "src_format".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "surface_area".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "src_format".into(),
+            "started_at".into(),
+            "status".into(),
+            "surface_area".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -5829,12 +5819,12 @@ impl std::fmt::Display for FileSystemMetadata {
 
 impl tabled::Tabled for FileSystemMetadata {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.ok)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![format!("{:?}", self.ok).into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["ok".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["ok".into()]
     }
 }
 
@@ -5882,53 +5872,53 @@ impl std::fmt::Display for FileVolume {
 
 impl tabled::Tabled for FileVolume {
     const LENGTH: usize = 10;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
-            format!("{:?}", self.src_format),
+            format!("{:?}", self.id).into(),
+            format!("{:?}", self.src_format).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(volume) = &self.volume {
-                format!("{:?}", volume)
+                format!("{:?}", volume).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "src_format".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
-            "volume".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "src_format".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
+            "volume".into(),
         ]
     }
 }
@@ -5967,43 +5957,43 @@ impl std::fmt::Display for Gateway {
 
 impl tabled::Tabled for Gateway {
     const LENGTH: usize = 5;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(auth_timeout) = &self.auth_timeout {
-                format!("{:?}", auth_timeout)
+                format!("{:?}", auth_timeout).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(host) = &self.host {
-                format!("{:?}", host)
+                format!("{:?}", host).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(port) = &self.port {
-                format!("{:?}", port)
+                format!("{:?}", port).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(tls_timeout) = &self.tls_timeout {
-                format!("{:?}", tls_timeout)
+                format!("{:?}", tls_timeout).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "auth_timeout".to_string(),
-            "host".to_string(),
-            "name".to_string(),
-            "port".to_string(),
-            "tls_timeout".to_string(),
+            "auth_timeout".into(),
+            "host".into(),
+            "name".into(),
+            "port".into(),
+            "tls_timeout".into(),
         ]
     }
 }
@@ -6062,37 +6052,37 @@ impl std::fmt::Display for IndexInfo {
 
 impl tabled::Tabled for IndexInfo {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(mirrors) = &self.mirrors {
-                format!("{:?}", mirrors)
+                format!("{:?}", mirrors).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(official) = &self.official {
-                format!("{:?}", official)
+                format!("{:?}", official).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(secure) = &self.secure {
-                format!("{:?}", secure)
+                format!("{:?}", secure).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "mirrors".to_string(),
-            "name".to_string(),
-            "official".to_string(),
-            "secure".to_string(),
+            "mirrors".into(),
+            "name".into(),
+            "official".into(),
+            "secure".into(),
         ]
     }
 }
@@ -6187,153 +6177,153 @@ impl std::fmt::Display for Invoice {
 
 impl tabled::Tabled for Invoice {
     const LENGTH: usize = 24;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(amount_due) = &self.amount_due {
-                format!("{:?}", amount_due)
+                format!("{:?}", amount_due).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(amount_paid) = &self.amount_paid {
-                format!("{:?}", amount_paid)
+                format!("{:?}", amount_paid).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(amount_remaining) = &self.amount_remaining {
-                format!("{:?}", amount_remaining)
+                format!("{:?}", amount_remaining).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(attempt_count) = &self.attempt_count {
-                format!("{:?}", attempt_count)
+                format!("{:?}", attempt_count).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(attempted) = &self.attempted {
-                format!("{:?}", attempted)
+                format!("{:?}", attempted).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(currency) = &self.currency {
-                format!("{:?}", currency)
+                format!("{:?}", currency).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(customer_email) = &self.customer_email {
-                format!("{:?}", customer_email)
+                format!("{:?}", customer_email).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(customer_id) = &self.customer_id {
-                format!("{:?}", customer_id)
+                format!("{:?}", customer_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(default_payment_method) = &self.default_payment_method {
-                format!("{:?}", default_payment_method)
+                format!("{:?}", default_payment_method).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(description) = &self.description {
-                format!("{:?}", description)
+                format!("{:?}", description).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(lines) = &self.lines {
-                format!("{:?}", lines)
+                format!("{:?}", lines).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(metadata) = &self.metadata {
-                format!("{:?}", metadata)
+                format!("{:?}", metadata).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(number) = &self.number {
-                format!("{:?}", number)
+                format!("{:?}", number).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(paid) = &self.paid {
-                format!("{:?}", paid)
+                format!("{:?}", paid).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(pdf) = &self.pdf {
-                format!("{:?}", pdf)
+                format!("{:?}", pdf).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(receipt_number) = &self.receipt_number {
-                format!("{:?}", receipt_number)
+                format!("{:?}", receipt_number).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(statement_descriptor) = &self.statement_descriptor {
-                format!("{:?}", statement_descriptor)
+                format!("{:?}", statement_descriptor).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(status) = &self.status {
-                format!("{:?}", status)
+                format!("{:?}", status).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(subtotal) = &self.subtotal {
-                format!("{:?}", subtotal)
+                format!("{:?}", subtotal).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(tax) = &self.tax {
-                format!("{:?}", tax)
+                format!("{:?}", tax).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(total) = &self.total {
-                format!("{:?}", total)
+                format!("{:?}", total).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(url) = &self.url {
-                format!("{:?}", url)
+                format!("{:?}", url).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "amount_due".to_string(),
-            "amount_paid".to_string(),
-            "amount_remaining".to_string(),
-            "attempt_count".to_string(),
-            "attempted".to_string(),
-            "created_at".to_string(),
-            "currency".to_string(),
-            "customer_email".to_string(),
-            "customer_id".to_string(),
-            "default_payment_method".to_string(),
-            "description".to_string(),
-            "id".to_string(),
-            "lines".to_string(),
-            "metadata".to_string(),
-            "number".to_string(),
-            "paid".to_string(),
-            "pdf".to_string(),
-            "receipt_number".to_string(),
-            "statement_descriptor".to_string(),
-            "status".to_string(),
-            "subtotal".to_string(),
-            "tax".to_string(),
-            "total".to_string(),
-            "url".to_string(),
+            "amount_due".into(),
+            "amount_paid".into(),
+            "amount_remaining".into(),
+            "attempt_count".into(),
+            "attempted".into(),
+            "created_at".into(),
+            "currency".into(),
+            "customer_email".into(),
+            "customer_id".into(),
+            "default_payment_method".into(),
+            "description".into(),
+            "id".into(),
+            "lines".into(),
+            "metadata".into(),
+            "number".into(),
+            "paid".into(),
+            "pdf".into(),
+            "receipt_number".into(),
+            "statement_descriptor".into(),
+            "status".into(),
+            "subtotal".into(),
+            "tax".into(),
+            "total".into(),
+            "url".into(),
         ]
     }
 }
@@ -6375,49 +6365,49 @@ impl std::fmt::Display for InvoiceLineItem {
 
 impl tabled::Tabled for InvoiceLineItem {
     const LENGTH: usize = 6;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(amount) = &self.amount {
-                format!("{:?}", amount)
+                format!("{:?}", amount).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(currency) = &self.currency {
-                format!("{:?}", currency)
+                format!("{:?}", currency).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(description) = &self.description {
-                format!("{:?}", description)
+                format!("{:?}", description).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(invoice_item) = &self.invoice_item {
-                format!("{:?}", invoice_item)
+                format!("{:?}", invoice_item).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(metadata) = &self.metadata {
-                format!("{:?}", metadata)
+                format!("{:?}", metadata).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "amount".to_string(),
-            "currency".to_string(),
-            "description".to_string(),
-            "id".to_string(),
-            "invoice_item".to_string(),
-            "metadata".to_string(),
+            "amount".into(),
+            "currency".into(),
+            "description".into(),
+            "id".into(),
+            "invoice_item".into(),
+            "metadata".into(),
         ]
     }
 }
@@ -6491,32 +6481,28 @@ impl std::fmt::Display for Jetstream {
 
 impl tabled::Tabled for Jetstream {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(config) = &self.config {
-                format!("{:?}", config)
+                format!("{:?}", config).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(meta) = &self.meta {
-                format!("{:?}", meta)
+                format!("{:?}", meta).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(stats) = &self.stats {
-                format!("{:?}", stats)
+                format!("{:?}", stats).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "config".to_string(),
-            "meta".to_string(),
-            "stats".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["config".into(), "meta".into(), "stats".into()]
     }
 }
 
@@ -6548,32 +6534,28 @@ impl std::fmt::Display for JetstreamApiStats {
 
 impl tabled::Tabled for JetstreamApiStats {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(errors) = &self.errors {
-                format!("{:?}", errors)
+                format!("{:?}", errors).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(inflight) = &self.inflight {
-                format!("{:?}", inflight)
+                format!("{:?}", inflight).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(total) = &self.total {
-                format!("{:?}", total)
+                format!("{:?}", total).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "errors".to_string(),
-            "inflight".to_string(),
-            "total".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["errors".into(), "inflight".into(), "total".into()]
     }
 }
 
@@ -6608,37 +6590,37 @@ impl std::fmt::Display for JetstreamConfig {
 
 impl tabled::Tabled for JetstreamConfig {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(domain) = &self.domain {
-                format!("{:?}", domain)
+                format!("{:?}", domain).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(max_memory) = &self.max_memory {
-                format!("{:?}", max_memory)
+                format!("{:?}", max_memory).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(max_storage) = &self.max_storage {
-                format!("{:?}", max_storage)
+                format!("{:?}", max_storage).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(store_dir) = &self.store_dir {
-                format!("{:?}", store_dir)
+                format!("{:?}", store_dir).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "domain".to_string(),
-            "max_memory".to_string(),
-            "max_storage".to_string(),
-            "store_dir".to_string(),
+            "domain".into(),
+            "max_memory".into(),
+            "max_storage".into(),
+            "store_dir".into(),
         ]
     }
 }
@@ -6683,55 +6665,55 @@ impl std::fmt::Display for JetstreamStats {
 
 impl tabled::Tabled for JetstreamStats {
     const LENGTH: usize = 7;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(accounts) = &self.accounts {
-                format!("{:?}", accounts)
+                format!("{:?}", accounts).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(api) = &self.api {
-                format!("{:?}", api)
+                format!("{:?}", api).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(ha_assets) = &self.ha_assets {
-                format!("{:?}", ha_assets)
+                format!("{:?}", ha_assets).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(memory) = &self.memory {
-                format!("{:?}", memory)
+                format!("{:?}", memory).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(reserved_memory) = &self.reserved_memory {
-                format!("{:?}", reserved_memory)
+                format!("{:?}", reserved_memory).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(reserved_store) = &self.reserved_store {
-                format!("{:?}", reserved_store)
+                format!("{:?}", reserved_store).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(store) = &self.store {
-                format!("{:?}", store)
+                format!("{:?}", store).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "accounts".to_string(),
-            "api".to_string(),
-            "ha_assets".to_string(),
-            "memory".to_string(),
-            "reserved_memory".to_string(),
-            "reserved_store".to_string(),
-            "store".to_string(),
+            "accounts".into(),
+            "api".into(),
+            "ha_assets".into(),
+            "memory".into(),
+            "reserved_memory".into(),
+            "reserved_store".into(),
+            "store".into(),
         ]
     }
 }
@@ -6767,37 +6749,37 @@ impl std::fmt::Display for LeafNode {
 
 impl tabled::Tabled for LeafNode {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(auth_timeout) = &self.auth_timeout {
-                format!("{:?}", auth_timeout)
+                format!("{:?}", auth_timeout).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(host) = &self.host {
-                format!("{:?}", host)
+                format!("{:?}", host).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(port) = &self.port {
-                format!("{:?}", port)
+                format!("{:?}", port).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(tls_timeout) = &self.tls_timeout {
-                format!("{:?}", tls_timeout)
+                format!("{:?}", tls_timeout).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "auth_timeout".to_string(),
-            "host".to_string(),
-            "port".to_string(),
-            "tls_timeout".to_string(),
+            "auth_timeout".into(),
+            "host".into(),
+            "port".into(),
+            "tls_timeout".into(),
         ]
     }
 }
@@ -6825,12 +6807,15 @@ impl std::fmt::Display for Line3D {
 
 impl tabled::Tabled for Line3D {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.from), format!("{:?}", self.to)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            format!("{:?}", self.from).into(),
+            format!("{:?}", self.to).into(),
+        ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["from".to_string(), "to".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["from".into(), "to".into()]
     }
 }
 
@@ -6853,12 +6838,12 @@ impl std::fmt::Display for Mesh {
 
 impl tabled::Tabled for Mesh {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![self.mesh.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![self.mesh.clone().into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["mesh".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["mesh".into()]
     }
 }
 
@@ -6890,32 +6875,28 @@ impl std::fmt::Display for MetaClusterInfo {
 
 impl tabled::Tabled for MetaClusterInfo {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(cluster_size) = &self.cluster_size {
-                format!("{:?}", cluster_size)
+                format!("{:?}", cluster_size).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(leader) = &self.leader {
-                format!("{:?}", leader)
+                format!("{:?}", leader).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "cluster_size".to_string(),
-            "leader".to_string(),
-            "name".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["cluster_size".into(), "leader".into(), "name".into()]
     }
 }
 
@@ -6954,29 +6935,29 @@ impl std::fmt::Display for Metadata {
 
 impl tabled::Tabled for Metadata {
     const LENGTH: usize = 8;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.cache),
-            format!("{:?}", self.engine),
-            format!("{:?}", self.environment),
-            format!("{:?}", self.executor),
-            format!("{:?}", self.fs),
-            self.git_hash.clone(),
-            format!("{:?}", self.point_e),
-            format!("{:?}", self.pubsub),
+            format!("{:?}", self.cache).into(),
+            format!("{:?}", self.engine).into(),
+            format!("{:?}", self.environment).into(),
+            format!("{:?}", self.executor).into(),
+            format!("{:?}", self.fs).into(),
+            self.git_hash.clone().into(),
+            format!("{:?}", self.point_e).into(),
+            format!("{:?}", self.pubsub).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "cache".to_string(),
-            "engine".to_string(),
-            "environment".to_string(),
-            "executor".to_string(),
-            "fs".to_string(),
-            "git_hash".to_string(),
-            "point_e".to_string(),
-            "pubsub".to_string(),
+            "cache".into(),
+            "engine".into(),
+            "environment".into(),
+            "executor".into(),
+            "fs".into(),
+            "git_hash".into(),
+            "point_e".into(),
+            "pubsub".into(),
         ]
     }
 }
@@ -7086,20 +7067,16 @@ impl std::fmt::Display for ModelingCmdReq {
 
 impl tabled::Tabled for ModelingCmdReq {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.cmd),
-            format!("{:?}", self.cmd_id),
-            self.file_id.clone(),
+            format!("{:?}", self.cmd).into(),
+            format!("{:?}", self.cmd_id).into(),
+            self.file_id.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "cmd".to_string(),
-            "cmd_id".to_string(),
-            "file_id".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["cmd".into(), "cmd_id".into(), "file_id".into()]
     }
 }
 
@@ -7126,12 +7103,15 @@ impl std::fmt::Display for ModelingCmdReqBatch {
 
 impl tabled::Tabled for ModelingCmdReqBatch {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.cmds), self.file_id.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            format!("{:?}", self.cmds).into(),
+            self.file_id.clone().into(),
+        ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["cmds".to_string(), "file_id".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["cmds".into(), "file_id".into()]
     }
 }
 
@@ -7162,21 +7142,21 @@ impl std::fmt::Display for ModelingError {
 
 impl tabled::Tabled for ModelingError {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.error_code.clone(),
-            self.external_message.clone(),
-            self.internal_message.clone(),
-            format!("{:?}", self.status_code),
+            self.error_code.clone().into(),
+            self.external_message.clone().into(),
+            self.internal_message.clone().into(),
+            format!("{:?}", self.status_code).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "error_code".to_string(),
-            "external_message".to_string(),
-            "internal_message".to_string(),
-            "status_code".to_string(),
+            "error_code".into(),
+            "external_message".into(),
+            "internal_message".into(),
+            "status_code".into(),
         ]
     }
 }
@@ -7223,12 +7203,12 @@ impl std::fmt::Display for ModelingOutcomes {
 
 impl tabled::Tabled for ModelingOutcomes {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.outcomes)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![format!("{:?}", self.outcomes).into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["outcomes".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["outcomes".into()]
     }
 }
 
@@ -7271,51 +7251,51 @@ impl std::fmt::Display for NewAddress {
 
 impl tabled::Tabled for NewAddress {
     const LENGTH: usize = 7;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(city) = &self.city {
-                format!("{:?}", city)
+                format!("{:?}", city).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.country),
+            format!("{:?}", self.country).into(),
             if let Some(state) = &self.state {
-                format!("{:?}", state)
+                format!("{:?}", state).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(street_1) = &self.street_1 {
-                format!("{:?}", street_1)
+                format!("{:?}", street_1).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(street_2) = &self.street_2 {
-                format!("{:?}", street_2)
+                format!("{:?}", street_2).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(zip) = &self.zip {
-                format!("{:?}", zip)
+                format!("{:?}", zip).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "city".to_string(),
-            "country".to_string(),
-            "state".to_string(),
-            "street_1".to_string(),
-            "street_2".to_string(),
-            "user_id".to_string(),
-            "zip".to_string(),
+            "city".into(),
+            "country".into(),
+            "state".into(),
+            "street_1".into(),
+            "street_2".into(),
+            "user_id".into(),
+            "zip".into(),
         ]
     }
 }
@@ -7348,31 +7328,31 @@ impl std::fmt::Display for Oauth2ClientInfo {
 
 impl tabled::Tabled for Oauth2ClientInfo {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(csrf_token) = &self.csrf_token {
-                format!("{:?}", csrf_token)
+                format!("{:?}", csrf_token).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(pkce_code_verifier) = &self.pkce_code_verifier {
-                format!("{:?}", pkce_code_verifier)
+                format!("{:?}", pkce_code_verifier).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(url) = &self.url {
-                format!("{:?}", url)
+                format!("{:?}", url).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "csrf_token".to_string(),
-            "pkce_code_verifier".to_string(),
-            "url".to_string(),
+            "csrf_token".into(),
+            "pkce_code_verifier".into(),
+            "url".into(),
         ]
     }
 }
@@ -7432,33 +7412,33 @@ impl std::fmt::Display for Onboarding {
 
 impl tabled::Tabled for Onboarding {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(first_call_from_their_machine_date) =
                 &self.first_call_from_their_machine_date
             {
-                format!("{:?}", first_call_from_their_machine_date)
+                format!("{:?}", first_call_from_their_machine_date).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(first_litterbox_execute_date) = &self.first_litterbox_execute_date {
-                format!("{:?}", first_litterbox_execute_date)
+                format!("{:?}", first_litterbox_execute_date).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(first_token_date) = &self.first_token_date {
-                format!("{:?}", first_token_date)
+                format!("{:?}", first_token_date).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "first_call_from_their_machine_date".to_string(),
-            "first_litterbox_execute_date".to_string(),
-            "first_token_date".to_string(),
+            "first_call_from_their_machine_date".into(),
+            "first_litterbox_execute_date".into(),
+            "first_token_date".into(),
         ]
     }
 }
@@ -7488,23 +7468,23 @@ impl std::fmt::Display for OutputFile {
 
 impl tabled::Tabled for OutputFile {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(contents) = &self.contents {
-                format!("{:?}", contents)
+                format!("{:?}", contents).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["contents".to_string(), "name".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["contents".into(), "name".into()]
     }
 }
 
@@ -7529,12 +7509,12 @@ impl std::fmt::Display for PaymentIntent {
 
 impl tabled::Tabled for PaymentIntent {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![self.client_secret.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![self.client_secret.clone().into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["client_secret".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["client_secret".into()]
     }
 }
 
@@ -7573,37 +7553,37 @@ impl std::fmt::Display for PaymentMethod {
 
 impl tabled::Tabled for PaymentMethod {
     const LENGTH: usize = 6;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.billing_info),
+            format!("{:?}", self.billing_info).into(),
             if let Some(card) = &self.card {
-                format!("{:?}", card)
+                format!("{:?}", card).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(metadata) = &self.metadata {
-                format!("{:?}", metadata)
+                format!("{:?}", metadata).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.type_),
+            format!("{:?}", self.type_).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "billing_info".to_string(),
-            "card".to_string(),
-            "created_at".to_string(),
-            "id".to_string(),
-            "metadata".to_string(),
-            "type_".to_string(),
+            "billing_info".into(),
+            "card".into(),
+            "created_at".into(),
+            "id".into(),
+            "metadata".into(),
+            "type_".into(),
         ]
     }
 }
@@ -7640,31 +7620,31 @@ impl std::fmt::Display for PaymentMethodCardChecks {
 
 impl tabled::Tabled for PaymentMethodCardChecks {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(address_line_1_check) = &self.address_line_1_check {
-                format!("{:?}", address_line_1_check)
+                format!("{:?}", address_line_1_check).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(address_postal_code_check) = &self.address_postal_code_check {
-                format!("{:?}", address_postal_code_check)
+                format!("{:?}", address_postal_code_check).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(cvc_check) = &self.cvc_check {
-                format!("{:?}", cvc_check)
+                format!("{:?}", cvc_check).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "address_line_1_check".to_string(),
-            "address_postal_code_check".to_string(),
-            "cvc_check".to_string(),
+            "address_line_1_check".into(),
+            "address_postal_code_check".into(),
+            "cvc_check".into(),
         ]
     }
 }
@@ -7740,53 +7720,53 @@ impl std::fmt::Display for PhysicsConstant {
 
 impl tabled::Tabled for PhysicsConstant {
     const LENGTH: usize = 10;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.constant),
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.constant).into(),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(value) = &self.value {
-                format!("{:?}", value)
+                format!("{:?}", value).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "constant".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
-            "value".to_string(),
+            "completed_at".into(),
+            "constant".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
+            "value".into(),
         ]
     }
 }
@@ -7965,37 +7945,37 @@ impl std::fmt::Display for PluginsInfo {
 
 impl tabled::Tabled for PluginsInfo {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(authorization) = &self.authorization {
-                format!("{:?}", authorization)
+                format!("{:?}", authorization).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(log) = &self.log {
-                format!("{:?}", log)
+                format!("{:?}", log).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(network) = &self.network {
-                format!("{:?}", network)
+                format!("{:?}", network).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(volume) = &self.volume {
-                format!("{:?}", volume)
+                format!("{:?}", volume).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "authorization".to_string(),
-            "log".to_string(),
-            "network".to_string(),
-            "volume".to_string(),
+            "authorization".into(),
+            "log".into(),
+            "network".into(),
+            "volume".into(),
         ]
     }
 }
@@ -8021,12 +8001,15 @@ impl std::fmt::Display for Point2D {
 
 impl tabled::Tabled for Point2D {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.x), format!("{:?}", self.y)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            format!("{:?}", self.x).into(),
+            format!("{:?}", self.y).into(),
+        ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["x".to_string(), "y".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["x".into(), "y".into()]
     }
 }
 
@@ -8052,16 +8035,16 @@ impl std::fmt::Display for Point3D {
 
 impl tabled::Tabled for Point3D {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.x),
-            format!("{:?}", self.y),
-            format!("{:?}", self.z),
+            format!("{:?}", self.x).into(),
+            format!("{:?}", self.y).into(),
+            format!("{:?}", self.z).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["x".to_string(), "y".to_string(), "z".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["x".into(), "y".into(), "z".into()]
     }
 }
 
@@ -8086,12 +8069,12 @@ impl std::fmt::Display for PointEMetadata {
 
 impl tabled::Tabled for PointEMetadata {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.ok)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![format!("{:?}", self.ok).into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["ok".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["ok".into()]
     }
 }
 
@@ -8116,12 +8099,12 @@ impl std::fmt::Display for Pong {
 
 impl tabled::Tabled for Pong {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![self.message.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![self.message.clone().into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["message".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["message".into()]
     }
 }
 
@@ -8158,47 +8141,47 @@ impl std::fmt::Display for RegistryServiceConfig {
 
 impl tabled::Tabled for RegistryServiceConfig {
     const LENGTH: usize = 5;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(allow_nondistributable_artifacts_cid_rs) =
                 &self.allow_nondistributable_artifacts_cid_rs
             {
-                format!("{:?}", allow_nondistributable_artifacts_cid_rs)
+                format!("{:?}", allow_nondistributable_artifacts_cid_rs).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(allow_nondistributable_artifacts_hostnames) =
                 &self.allow_nondistributable_artifacts_hostnames
             {
-                format!("{:?}", allow_nondistributable_artifacts_hostnames)
+                format!("{:?}", allow_nondistributable_artifacts_hostnames).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(index_configs) = &self.index_configs {
-                format!("{:?}", index_configs)
+                format!("{:?}", index_configs).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(insecure_registry_cid_rs) = &self.insecure_registry_cid_rs {
-                format!("{:?}", insecure_registry_cid_rs)
+                format!("{:?}", insecure_registry_cid_rs).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(mirrors) = &self.mirrors {
-                format!("{:?}", mirrors)
+                format!("{:?}", mirrors).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "allow_nondistributable_artifacts_cid_rs".to_string(),
-            "allow_nondistributable_artifacts_hostnames".to_string(),
-            "index_configs".to_string(),
-            "insecure_registry_cid_rs".to_string(),
-            "mirrors".to_string(),
+            "allow_nondistributable_artifacts_cid_rs".into(),
+            "allow_nondistributable_artifacts_hostnames".into(),
+            "index_configs".into(),
+            "insecure_registry_cid_rs".into(),
+            "mirrors".into(),
         ]
     }
 }
@@ -8228,23 +8211,23 @@ impl std::fmt::Display for Runtime {
 
 impl tabled::Tabled for Runtime {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(path) = &self.path {
-                format!("{:?}", path)
+                format!("{:?}", path).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(runtime_args) = &self.runtime_args {
-                format!("{:?}", runtime_args)
+                format!("{:?}", runtime_args).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["path".to_string(), "runtime_args".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["path".into(), "runtime_args".into()]
     }
 }
 
@@ -8281,33 +8264,33 @@ impl std::fmt::Display for Session {
 
 impl tabled::Tabled for Session {
     const LENGTH: usize = 6;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.created_at),
-            format!("{:?}", self.expires),
+            format!("{:?}", self.created_at).into(),
+            format!("{:?}", self.expires).into(),
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.session_token),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.session_token).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "created_at".to_string(),
-            "expires".to_string(),
-            "id".to_string(),
-            "session_token".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "created_at".into(),
+            "expires".into(),
+            "id".into(),
+            "session_token".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -8389,23 +8372,23 @@ impl std::fmt::Display for SystemInfoDefaultAddressPools {
 
 impl tabled::Tabled for SystemInfoDefaultAddressPools {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(base) = &self.base {
-                format!("{:?}", base)
+                format!("{:?}", base).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(size) = &self.size {
-                format!("{:?}", size)
+                format!("{:?}", size).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["base".to_string(), "size".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["base".into(), "size".into()]
     }
 }
 
@@ -8511,61 +8494,61 @@ impl std::fmt::Display for UnitAngleConversion {
 
 impl tabled::Tabled for UnitAngleConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -8692,61 +8675,61 @@ impl std::fmt::Display for UnitAreaConversion {
 
 impl tabled::Tabled for UnitAreaConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -8833,61 +8816,61 @@ impl std::fmt::Display for UnitCurrentConversion {
 
 impl tabled::Tabled for UnitCurrentConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -8982,61 +8965,61 @@ impl std::fmt::Display for UnitEnergyConversion {
 
 impl tabled::Tabled for UnitEnergyConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -9135,61 +9118,61 @@ impl std::fmt::Display for UnitForceConversion {
 
 impl tabled::Tabled for UnitForceConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -9292,61 +9275,61 @@ impl std::fmt::Display for UnitFrequencyConversion {
 
 impl tabled::Tabled for UnitFrequencyConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -9469,61 +9452,61 @@ impl std::fmt::Display for UnitLengthConversion {
 
 impl tabled::Tabled for UnitLengthConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -9654,61 +9637,61 @@ impl std::fmt::Display for UnitMassConversion {
 
 impl tabled::Tabled for UnitMassConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -9807,61 +9790,61 @@ impl std::fmt::Display for UnitPowerConversion {
 
 impl tabled::Tabled for UnitPowerConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -9960,61 +9943,61 @@ impl std::fmt::Display for UnitPressureConversion {
 
 impl tabled::Tabled for UnitPressureConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -10101,61 +10084,61 @@ impl std::fmt::Display for UnitTemperatureConversion {
 
 impl tabled::Tabled for UnitTemperatureConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -10234,61 +10217,61 @@ impl std::fmt::Display for UnitTorqueConversion {
 
 impl tabled::Tabled for UnitTorqueConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -10435,61 +10418,61 @@ impl std::fmt::Display for UnitVolumeConversion {
 
 impl tabled::Tabled for UnitVolumeConversion {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(completed_at) = &self.completed_at {
-                format!("{:?}", completed_at)
+                format!("{:?}", completed_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(error) = &self.error {
-                format!("{:?}", error)
+                format!("{:?}", error).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
+            format!("{:?}", self.id).into(),
             if let Some(input) = &self.input {
-                format!("{:?}", input)
+                format!("{:?}", input).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.input_unit),
+            format!("{:?}", self.input_unit).into(),
             if let Some(output) = &self.output {
-                format!("{:?}", output)
+                format!("{:?}", output).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.output_unit),
+            format!("{:?}", self.output_unit).into(),
             if let Some(started_at) = &self.started_at {
-                format!("{:?}", started_at)
+                format!("{:?}", started_at).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.status),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.updated_at).into(),
             if let Some(user_id) = &self.user_id {
-                format!("{:?}", user_id)
+                format!("{:?}", user_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "completed_at".to_string(),
-            "created_at".to_string(),
-            "error".to_string(),
-            "id".to_string(),
-            "input".to_string(),
-            "input_unit".to_string(),
-            "output".to_string(),
-            "output_unit".to_string(),
-            "started_at".to_string(),
-            "status".to_string(),
-            "updated_at".to_string(),
-            "user_id".to_string(),
+            "completed_at".into(),
+            "created_at".into(),
+            "error".into(),
+            "id".into(),
+            "input".into(),
+            "input_unit".into(),
+            "output".into(),
+            "output_unit".into(),
+            "started_at".into(),
+            "status".into(),
+            "updated_at".into(),
+            "user_id".into(),
         ]
     }
 }
@@ -10531,45 +10514,45 @@ impl std::fmt::Display for UpdateUser {
 
 impl tabled::Tabled for UpdateUser {
     const LENGTH: usize = 6;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(company) = &self.company {
-                format!("{:?}", company)
+                format!("{:?}", company).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(discord) = &self.discord {
-                format!("{:?}", discord)
+                format!("{:?}", discord).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(first_name) = &self.first_name {
-                format!("{:?}", first_name)
+                format!("{:?}", first_name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(github) = &self.github {
-                format!("{:?}", github)
+                format!("{:?}", github).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(last_name) = &self.last_name {
-                format!("{:?}", last_name)
+                format!("{:?}", last_name).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.phone),
+            format!("{:?}", self.phone).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "company".to_string(),
-            "discord".to_string(),
-            "first_name".to_string(),
-            "github".to_string(),
-            "last_name".to_string(),
-            "phone".to_string(),
+            "company".into(),
+            "discord".into(),
+            "first_name".into(),
+            "github".into(),
+            "last_name".into(),
+            "phone".into(),
         ]
     }
 }
@@ -10629,75 +10612,75 @@ impl std::fmt::Display for User {
 
 impl tabled::Tabled for User {
     const LENGTH: usize = 13;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(company) = &self.company {
-                format!("{:?}", company)
+                format!("{:?}", company).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.created_at),
+            format!("{:?}", self.created_at).into(),
             if let Some(discord) = &self.discord {
-                format!("{:?}", discord)
+                format!("{:?}", discord).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(email) = &self.email {
-                format!("{:?}", email)
+                format!("{:?}", email).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(email_verified) = &self.email_verified {
-                format!("{:?}", email_verified)
+                format!("{:?}", email_verified).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(first_name) = &self.first_name {
-                format!("{:?}", first_name)
+                format!("{:?}", first_name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(github) = &self.github {
-                format!("{:?}", github)
+                format!("{:?}", github).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.image.clone(),
+            self.image.clone().into(),
             if let Some(last_name) = &self.last_name {
-                format!("{:?}", last_name)
+                format!("{:?}", last_name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.phone),
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.phone).into(),
+            format!("{:?}", self.updated_at).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "company".to_string(),
-            "created_at".to_string(),
-            "discord".to_string(),
-            "email".to_string(),
-            "email_verified".to_string(),
-            "first_name".to_string(),
-            "github".to_string(),
-            "id".to_string(),
-            "image".to_string(),
-            "last_name".to_string(),
-            "name".to_string(),
-            "phone".to_string(),
-            "updated_at".to_string(),
+            "company".into(),
+            "created_at".into(),
+            "discord".into(),
+            "email".into(),
+            "email_verified".into(),
+            "first_name".into(),
+            "github".into(),
+            "id".into(),
+            "image".into(),
+            "last_name".into(),
+            "name".into(),
+            "phone".into(),
+            "updated_at".into(),
         ]
     }
 }
@@ -10753,19 +10736,19 @@ impl crate::types::paginate::Pagination for UserResultsPage {
 
 impl tabled::Tabled for UserResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -10800,31 +10783,31 @@ impl std::fmt::Display for VerificationToken {
 
 impl tabled::Tabled for VerificationToken {
     const LENGTH: usize = 5;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.created_at),
-            format!("{:?}", self.expires),
+            format!("{:?}", self.created_at).into(),
+            format!("{:?}", self.expires).into(),
             if let Some(id) = &self.id {
-                format!("{:?}", id)
+                format!("{:?}", id).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(identifier) = &self.identifier {
-                format!("{:?}", identifier)
+                format!("{:?}", identifier).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.updated_at),
+            format!("{:?}", self.updated_at).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "created_at".to_string(),
-            "expires".to_string(),
-            "id".to_string(),
-            "identifier".to_string(),
-            "updated_at".to_string(),
+            "created_at".into(),
+            "expires".into(),
+            "id".into(),
+            "identifier".into(),
+            "updated_at".into(),
         ]
     }
 }

--- a/openapitor/tests/types/oxide.digest.rs.gen
+++ b/openapitor/tests/types/oxide.digest.rs.gen
@@ -44,11 +44,14 @@ impl std::fmt::Display for Digest {
 
 impl tabled::Tabled for Digest {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.type_), self.value.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            format!("{:?}", self.type_).into(),
+            self.value.clone().into(),
+        ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["type_".to_string(), "value".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["type_".into(), "value".into()]
     }
 }

--- a/openapitor/tests/types/oxide.router-route.rs.gen
+++ b/openapitor/tests/types/oxide.router-route.rs.gen
@@ -35,31 +35,31 @@ impl std::fmt::Display for RouterRoute {
 
 impl tabled::Tabled for RouterRoute {
     const LENGTH: usize = 9;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            format!("{:?}", self.destination),
-            format!("{:?}", self.id),
-            format!("{:?}", self.kind),
-            self.name.clone(),
-            format!("{:?}", self.target),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
-            format!("{:?}", self.vpc_router_id),
+            self.description.clone().into(),
+            format!("{:?}", self.destination).into(),
+            format!("{:?}", self.id).into(),
+            format!("{:?}", self.kind).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.target).into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
+            format!("{:?}", self.vpc_router_id).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "destination".to_string(),
-            "id".to_string(),
-            "kind".to_string(),
-            "name".to_string(),
-            "target".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
-            "vpc_router_id".to_string(),
+            "description".into(),
+            "destination".into(),
+            "id".into(),
+            "kind".into(),
+            "name".into(),
+            "target".into(),
+            "time_created".into(),
+            "time_modified".into(),
+            "vpc_router_id".into(),
         ]
     }
 }

--- a/openapitor/tests/types/oxide.rs.gen
+++ b/openapitor/tests/types/oxide.rs.gen
@@ -468,12 +468,15 @@ impl std::fmt::Display for DerEncodedKeyPair {
 
 impl tabled::Tabled for DerEncodedKeyPair {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![self.private_key.clone(), self.public_cert.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            self.private_key.clone().into(),
+            self.public_cert.clone().into(),
+        ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["private_key".to_string(), "public_cert".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["private_key".into(), "public_cert".into()]
     }
 }
 
@@ -498,19 +501,19 @@ impl std::fmt::Display for DeviceAccessTokenRequest {
 
 impl tabled::Tabled for DeviceAccessTokenRequest {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.client_id),
-            self.device_code.clone(),
-            self.grant_type.clone(),
+            format!("{:?}", self.client_id).into(),
+            self.device_code.clone().into(),
+            self.grant_type.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "client_id".to_string(),
-            "device_code".to_string(),
-            "grant_type".to_string(),
+            "client_id".into(),
+            "device_code".into(),
+            "grant_type".into(),
         ]
     }
 }
@@ -534,12 +537,12 @@ impl std::fmt::Display for DeviceAuthRequest {
 
 impl tabled::Tabled for DeviceAuthRequest {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.client_id)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![format!("{:?}", self.client_id).into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["client_id".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["client_id".into()]
     }
 }
 
@@ -562,12 +565,12 @@ impl std::fmt::Display for DeviceAuthVerify {
 
 impl tabled::Tabled for DeviceAuthVerify {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![self.user_code.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![self.user_code.clone().into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["user_code".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["user_code".into()]
     }
 }
 
@@ -617,12 +620,15 @@ impl std::fmt::Display for Digest {
 
 impl tabled::Tabled for Digest {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.type_), self.value.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            format!("{:?}", self.type_).into(),
+            self.value.clone().into(),
+        ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["type_".to_string(), "value".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["type_".into(), "value".into()]
     }
 }
 
@@ -667,45 +673,45 @@ impl std::fmt::Display for Disk {
 
 impl tabled::Tabled for Disk {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.block_size),
-            self.description.clone(),
-            self.device_path.clone(),
-            format!("{:?}", self.id),
+            format!("{:?}", self.block_size).into(),
+            self.description.clone().into(),
+            self.device_path.clone().into(),
+            format!("{:?}", self.id).into(),
             if let Some(image_id) = &self.image_id {
-                format!("{:?}", image_id)
+                format!("{:?}", image_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.name.clone(),
-            format!("{:?}", self.project_id),
-            format!("{:?}", self.size),
+            self.name.clone().into(),
+            format!("{:?}", self.project_id).into(),
+            format!("{:?}", self.size).into(),
             if let Some(snapshot_id) = &self.snapshot_id {
-                format!("{:?}", snapshot_id)
+                format!("{:?}", snapshot_id).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.state),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
+            format!("{:?}", self.state).into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "block_size".to_string(),
-            "description".to_string(),
-            "device_path".to_string(),
-            "id".to_string(),
-            "image_id".to_string(),
-            "name".to_string(),
-            "project_id".to_string(),
-            "size".to_string(),
-            "snapshot_id".to_string(),
-            "state".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
+            "block_size".into(),
+            "description".into(),
+            "device_path".into(),
+            "id".into(),
+            "image_id".into(),
+            "name".into(),
+            "project_id".into(),
+            "size".into(),
+            "snapshot_id".into(),
+            "state".into(),
+            "time_created".into(),
+            "time_modified".into(),
         ]
     }
 }
@@ -736,21 +742,21 @@ impl std::fmt::Display for DiskCreate {
 
 impl tabled::Tabled for DiskCreate {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            format!("{:?}", self.disk_source),
-            self.name.clone(),
-            format!("{:?}", self.size),
+            self.description.clone().into(),
+            format!("{:?}", self.disk_source).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.size).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "disk_source".to_string(),
-            "name".to_string(),
-            "size".to_string(),
+            "description".into(),
+            "disk_source".into(),
+            "name".into(),
+            "size".into(),
         ]
     }
 }
@@ -776,12 +782,12 @@ impl std::fmt::Display for DiskIdentifier {
 
 impl tabled::Tabled for DiskIdentifier {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![self.name.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![self.name.clone().into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["name".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["name".into()]
     }
 }
 
@@ -836,19 +842,19 @@ impl crate::types::paginate::Pagination for DiskResultsPage {
 
 impl tabled::Tabled for DiskResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -925,12 +931,12 @@ impl std::fmt::Display for Distribution {
 
 impl tabled::Tabled for Distribution {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![self.name.clone(), self.version.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![self.name.clone().into(), self.version.clone().into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["name".to_string(), "version".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["name".into(), "version".into()]
     }
 }
 
@@ -957,24 +963,20 @@ impl std::fmt::Display for Error {
 
 impl tabled::Tabled for Error {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(error_code) = &self.error_code {
-                format!("{:?}", error_code)
+                format!("{:?}", error_code).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.message.clone(),
-            self.request_id.clone(),
+            self.message.clone().into(),
+            self.request_id.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "error_code".to_string(),
-            "message".to_string(),
-            "request_id".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["error_code".into(), "message".into(), "request_id".into()]
     }
 }
 
@@ -1002,16 +1004,16 @@ impl std::fmt::Display for FieldSchema {
 
 impl tabled::Tabled for FieldSchema {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.name.clone(),
-            format!("{:?}", self.source),
-            format!("{:?}", self.ty),
+            self.name.clone().into(),
+            format!("{:?}", self.source).into(),
+            format!("{:?}", self.ty).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["name".to_string(), "source".to_string(), "ty".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["name".into(), "source".into(), "ty".into()]
     }
 }
 
@@ -1116,12 +1118,12 @@ impl std::fmt::Display for FleetRolePolicy {
 
 impl tabled::Tabled for FleetRolePolicy {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.role_assignments)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![format!("{:?}", self.role_assignments).into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["role_assignments".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["role_assignments".into()]
     }
 }
 
@@ -1148,19 +1150,19 @@ impl std::fmt::Display for FleetRoleRoleAssignment {
 
 impl tabled::Tabled for FleetRoleRoleAssignment {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.identity_id),
-            format!("{:?}", self.identity_type),
-            format!("{:?}", self.role_name),
+            format!("{:?}", self.identity_id).into(),
+            format!("{:?}", self.identity_type).into(),
+            format!("{:?}", self.role_name).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "identity_id".to_string(),
-            "identity_type".to_string(),
-            "role_name".to_string(),
+            "identity_id".into(),
+            "identity_type".into(),
+            "role_name".into(),
         ]
     }
 }
@@ -1208,43 +1210,43 @@ impl std::fmt::Display for GlobalImage {
 
 impl tabled::Tabled for GlobalImage {
     const LENGTH: usize = 11;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.block_size),
-            self.description.clone(),
+            format!("{:?}", self.block_size).into(),
+            self.description.clone().into(),
             if let Some(digest) = &self.digest {
-                format!("{:?}", digest)
+                format!("{:?}", digest).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.distribution.clone(),
-            format!("{:?}", self.id),
-            self.name.clone(),
-            format!("{:?}", self.size),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
+            self.distribution.clone().into(),
+            format!("{:?}", self.id).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.size).into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
             if let Some(url) = &self.url {
-                format!("{:?}", url)
+                format!("{:?}", url).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.version.clone(),
+            self.version.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "block_size".to_string(),
-            "description".to_string(),
-            "digest".to_string(),
-            "distribution".to_string(),
-            "id".to_string(),
-            "name".to_string(),
-            "size".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
-            "url".to_string(),
-            "version".to_string(),
+            "block_size".into(),
+            "description".into(),
+            "digest".into(),
+            "distribution".into(),
+            "id".into(),
+            "name".into(),
+            "size".into(),
+            "time_created".into(),
+            "time_modified".into(),
+            "url".into(),
+            "version".into(),
         ]
     }
 }
@@ -1277,23 +1279,23 @@ impl std::fmt::Display for GlobalImageCreate {
 
 impl tabled::Tabled for GlobalImageCreate {
     const LENGTH: usize = 5;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.block_size),
-            self.description.clone(),
-            format!("{:?}", self.distribution),
-            self.name.clone(),
-            format!("{:?}", self.source),
+            format!("{:?}", self.block_size).into(),
+            self.description.clone().into(),
+            format!("{:?}", self.distribution).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.source).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "block_size".to_string(),
-            "description".to_string(),
-            "distribution".to_string(),
-            "name".to_string(),
-            "source".to_string(),
+            "block_size".into(),
+            "description".into(),
+            "distribution".into(),
+            "name".into(),
+            "source".into(),
         ]
     }
 }
@@ -1349,19 +1351,19 @@ impl crate::types::paginate::Pagination for GlobalImageResultsPage {
 
 impl tabled::Tabled for GlobalImageResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -1396,25 +1398,25 @@ impl std::fmt::Display for IdentityProvider {
 
 impl tabled::Tabled for IdentityProvider {
     const LENGTH: usize = 6;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            format!("{:?}", self.id),
-            self.name.clone(),
-            format!("{:?}", self.provider_type),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
+            self.description.clone().into(),
+            format!("{:?}", self.id).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.provider_type).into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "id".to_string(),
-            "name".to_string(),
-            "provider_type".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
+            "description".into(),
+            "id".into(),
+            "name".into(),
+            "provider_type".into(),
+            "time_created".into(),
+            "time_modified".into(),
         ]
     }
 }
@@ -1470,19 +1472,19 @@ impl crate::types::paginate::Pagination for IdentityProviderResultsPage {
 
 impl tabled::Tabled for IdentityProviderResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -1598,47 +1600,47 @@ impl std::fmt::Display for Image {
 
 impl tabled::Tabled for Image {
     const LENGTH: usize = 11;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.block_size),
-            self.description.clone(),
+            format!("{:?}", self.block_size).into(),
+            self.description.clone().into(),
             if let Some(digest) = &self.digest {
-                format!("{:?}", digest)
+                format!("{:?}", digest).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.id),
-            self.name.clone(),
-            format!("{:?}", self.project_id),
-            format!("{:?}", self.size),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
+            format!("{:?}", self.id).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.project_id).into(),
+            format!("{:?}", self.size).into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
             if let Some(url) = &self.url {
-                format!("{:?}", url)
+                format!("{:?}", url).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(version) = &self.version {
-                format!("{:?}", version)
+                format!("{:?}", version).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "block_size".to_string(),
-            "description".to_string(),
-            "digest".to_string(),
-            "id".to_string(),
-            "name".to_string(),
-            "project_id".to_string(),
-            "size".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
-            "url".to_string(),
-            "version".to_string(),
+            "block_size".into(),
+            "description".into(),
+            "digest".into(),
+            "id".into(),
+            "name".into(),
+            "project_id".into(),
+            "size".into(),
+            "time_created".into(),
+            "time_modified".into(),
+            "url".into(),
+            "version".into(),
         ]
     }
 }
@@ -1669,21 +1671,21 @@ impl std::fmt::Display for ImageCreate {
 
 impl tabled::Tabled for ImageCreate {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.block_size),
-            self.description.clone(),
-            self.name.clone(),
-            format!("{:?}", self.source),
+            format!("{:?}", self.block_size).into(),
+            self.description.clone().into(),
+            self.name.clone().into(),
+            format!("{:?}", self.source).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "block_size".to_string(),
-            "description".to_string(),
-            "name".to_string(),
-            "source".to_string(),
+            "block_size".into(),
+            "description".into(),
+            "name".into(),
+            "source".into(),
         ]
     }
 }
@@ -1739,19 +1741,19 @@ impl crate::types::paginate::Pagination for ImageResultsPage {
 
 impl tabled::Tabled for ImageResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -1815,35 +1817,35 @@ impl std::fmt::Display for Instance {
 
 impl tabled::Tabled for Instance {
     const LENGTH: usize = 11;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            self.hostname.clone(),
-            format!("{:?}", self.id),
-            format!("{:?}", self.memory),
-            self.name.clone(),
-            format!("{:?}", self.ncpus),
-            format!("{:?}", self.project_id),
-            format!("{:?}", self.run_state),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
-            format!("{:?}", self.time_run_state_updated),
+            self.description.clone().into(),
+            self.hostname.clone().into(),
+            format!("{:?}", self.id).into(),
+            format!("{:?}", self.memory).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.ncpus).into(),
+            format!("{:?}", self.project_id).into(),
+            format!("{:?}", self.run_state).into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
+            format!("{:?}", self.time_run_state_updated).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "hostname".to_string(),
-            "id".to_string(),
-            "memory".to_string(),
-            "name".to_string(),
-            "ncpus".to_string(),
-            "project_id".to_string(),
-            "run_state".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
-            "time_run_state_updated".to_string(),
+            "description".into(),
+            "hostname".into(),
+            "id".into(),
+            "memory".into(),
+            "name".into(),
+            "ncpus".into(),
+            "project_id".into(),
+            "run_state".into(),
+            "time_created".into(),
+            "time_modified".into(),
+            "time_run_state_updated".into(),
         ]
     }
 }
@@ -1884,41 +1886,41 @@ impl std::fmt::Display for InstanceCreate {
 
 impl tabled::Tabled for InstanceCreate {
     const LENGTH: usize = 8;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
+            self.description.clone().into(),
             if let Some(disks) = &self.disks {
-                format!("{:?}", disks)
+                format!("{:?}", disks).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.hostname.clone(),
-            format!("{:?}", self.memory),
-            self.name.clone(),
-            format!("{:?}", self.ncpus),
+            self.hostname.clone().into(),
+            format!("{:?}", self.memory).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.ncpus).into(),
             if let Some(network_interfaces) = &self.network_interfaces {
-                format!("{:?}", network_interfaces)
+                format!("{:?}", network_interfaces).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(user_data) = &self.user_data {
-                format!("{:?}", user_data)
+                format!("{:?}", user_data).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "disks".to_string(),
-            "hostname".to_string(),
-            "memory".to_string(),
-            "name".to_string(),
-            "ncpus".to_string(),
-            "network_interfaces".to_string(),
-            "user_data".to_string(),
+            "description".into(),
+            "disks".into(),
+            "hostname".into(),
+            "memory".into(),
+            "name".into(),
+            "ncpus".into(),
+            "network_interfaces".into(),
+            "user_data".into(),
         ]
     }
 }
@@ -1966,12 +1968,12 @@ impl std::fmt::Display for InstanceMigrate {
 
 impl tabled::Tabled for InstanceMigrate {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.dst_sled_id)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![format!("{:?}", self.dst_sled_id).into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["dst_sled_id".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["dst_sled_id".into()]
     }
 }
 
@@ -2046,19 +2048,19 @@ impl crate::types::paginate::Pagination for InstanceResultsPage {
 
 impl tabled::Tabled for InstanceResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -2085,15 +2087,15 @@ impl std::fmt::Display for InstanceSerialConsoleData {
 
 impl tabled::Tabled for InstanceSerialConsoleData {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.data),
-            format!("{:?}", self.last_byte_offset),
+            format!("{:?}", self.data).into(),
+            format!("{:?}", self.last_byte_offset).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["data".to_string(), "last_byte_offset".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["data".into(), "last_byte_offset".into()]
     }
 }
 
@@ -2187,23 +2189,23 @@ impl std::fmt::Display for IpPool {
 
 impl tabled::Tabled for IpPool {
     const LENGTH: usize = 5;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            format!("{:?}", self.id),
-            self.name.clone(),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
+            self.description.clone().into(),
+            format!("{:?}", self.id).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "id".to_string(),
-            "name".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
+            "description".into(),
+            "id".into(),
+            "name".into(),
+            "time_created".into(),
+            "time_modified".into(),
         ]
     }
 }
@@ -2230,12 +2232,12 @@ impl std::fmt::Display for IpPoolCreate {
 
 impl tabled::Tabled for IpPoolCreate {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![self.description.clone(), self.name.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![self.description.clone().into(), self.name.clone().into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["description".to_string(), "name".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["description".into(), "name".into()]
     }
 }
 
@@ -2260,20 +2262,16 @@ impl std::fmt::Display for IpPoolRange {
 
 impl tabled::Tabled for IpPoolRange {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.id),
-            format!("{:?}", self.range),
-            format!("{:?}", self.time_created),
+            format!("{:?}", self.id).into(),
+            format!("{:?}", self.range).into(),
+            format!("{:?}", self.time_created).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "id".to_string(),
-            "range".to_string(),
-            "time_created".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["id".into(), "range".into(), "time_created".into()]
     }
 }
 
@@ -2328,19 +2326,19 @@ impl crate::types::paginate::Pagination for IpPoolRangeResultsPage {
 
 impl tabled::Tabled for IpPoolRangeResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -2395,19 +2393,19 @@ impl crate::types::paginate::Pagination for IpPoolResultsPage {
 
 impl tabled::Tabled for IpPoolResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -2434,23 +2432,23 @@ impl std::fmt::Display for IpPoolUpdate {
 
 impl tabled::Tabled for IpPoolUpdate {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(description) = &self.description {
-                format!("{:?}", description)
+                format!("{:?}", description).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["description".to_string(), "name".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["description".into(), "name".into()]
     }
 }
 
@@ -2489,12 +2487,15 @@ impl std::fmt::Display for Ipv4Range {
 
 impl tabled::Tabled for Ipv4Range {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.first), format!("{:?}", self.last)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            format!("{:?}", self.first).into(),
+            format!("{:?}", self.last).into(),
+        ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["first".to_string(), "last".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["first".into(), "last".into()]
     }
 }
 
@@ -2519,12 +2520,15 @@ impl std::fmt::Display for Ipv6Range {
 
 impl tabled::Tabled for Ipv6Range {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.first), format!("{:?}", self.last)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            format!("{:?}", self.first).into(),
+            format!("{:?}", self.last).into(),
+        ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["first".to_string(), "last".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["first".into(), "last".into()]
     }
 }
 
@@ -2569,35 +2573,35 @@ impl std::fmt::Display for NetworkInterface {
 
 impl tabled::Tabled for NetworkInterface {
     const LENGTH: usize = 11;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            format!("{:?}", self.id),
-            format!("{:?}", self.instance_id),
-            format!("{:?}", self.ip),
-            self.mac.clone(),
-            self.name.clone(),
-            format!("{:?}", self.primary),
-            format!("{:?}", self.subnet_id),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
-            format!("{:?}", self.vpc_id),
+            self.description.clone().into(),
+            format!("{:?}", self.id).into(),
+            format!("{:?}", self.instance_id).into(),
+            format!("{:?}", self.ip).into(),
+            self.mac.clone().into(),
+            self.name.clone().into(),
+            format!("{:?}", self.primary).into(),
+            format!("{:?}", self.subnet_id).into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
+            format!("{:?}", self.vpc_id).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "id".to_string(),
-            "instance_id".to_string(),
-            "ip".to_string(),
-            "mac".to_string(),
-            "name".to_string(),
-            "primary".to_string(),
-            "subnet_id".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
-            "vpc_id".to_string(),
+            "description".into(),
+            "id".into(),
+            "instance_id".into(),
+            "ip".into(),
+            "mac".into(),
+            "name".into(),
+            "primary".into(),
+            "subnet_id".into(),
+            "time_created".into(),
+            "time_modified".into(),
+            "vpc_id".into(),
         ]
     }
 }
@@ -2631,27 +2635,27 @@ impl std::fmt::Display for NetworkInterfaceCreate {
 
 impl tabled::Tabled for NetworkInterfaceCreate {
     const LENGTH: usize = 5;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
+            self.description.clone().into(),
             if let Some(ip) = &self.ip {
-                format!("{:?}", ip)
+                format!("{:?}", ip).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.name.clone(),
-            self.subnet_name.clone(),
-            self.vpc_name.clone(),
+            self.name.clone().into(),
+            self.subnet_name.clone().into(),
+            self.vpc_name.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "ip".to_string(),
-            "name".to_string(),
-            "subnet_name".to_string(),
-            "vpc_name".to_string(),
+            "description".into(),
+            "ip".into(),
+            "name".into(),
+            "subnet_name".into(),
+            "vpc_name".into(),
         ]
     }
 }
@@ -2707,19 +2711,19 @@ impl crate::types::paginate::Pagination for NetworkInterfaceResultsPage {
 
 impl tabled::Tabled for NetworkInterfaceResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -2749,32 +2753,28 @@ impl std::fmt::Display for NetworkInterfaceUpdate {
 
 impl tabled::Tabled for NetworkInterfaceUpdate {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(description) = &self.description {
-                format!("{:?}", description)
+                format!("{:?}", description).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(make_primary) = &self.make_primary {
-                format!("{:?}", make_primary)
+                format!("{:?}", make_primary).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "description".to_string(),
-            "make_primary".to_string(),
-            "name".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["description".into(), "make_primary".into(), "name".into()]
     }
 }
 
@@ -2807,23 +2807,23 @@ impl std::fmt::Display for Organization {
 
 impl tabled::Tabled for Organization {
     const LENGTH: usize = 5;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            format!("{:?}", self.id),
-            self.name.clone(),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
+            self.description.clone().into(),
+            format!("{:?}", self.id).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "id".to_string(),
-            "name".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
+            "description".into(),
+            "id".into(),
+            "name".into(),
+            "time_created".into(),
+            "time_modified".into(),
         ]
     }
 }
@@ -2850,12 +2850,12 @@ impl std::fmt::Display for OrganizationCreate {
 
 impl tabled::Tabled for OrganizationCreate {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![self.description.clone(), self.name.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![self.description.clone().into(), self.name.clone().into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["description".to_string(), "name".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["description".into(), "name".into()]
     }
 }
 
@@ -2910,19 +2910,19 @@ impl crate::types::paginate::Pagination for OrganizationResultsPage {
 
 impl tabled::Tabled for OrganizationResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -2972,12 +2972,12 @@ impl std::fmt::Display for OrganizationRolePolicy {
 
 impl tabled::Tabled for OrganizationRolePolicy {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.role_assignments)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![format!("{:?}", self.role_assignments).into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["role_assignments".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["role_assignments".into()]
     }
 }
 
@@ -3004,19 +3004,19 @@ impl std::fmt::Display for OrganizationRoleRoleAssignment {
 
 impl tabled::Tabled for OrganizationRoleRoleAssignment {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.identity_id),
-            format!("{:?}", self.identity_type),
-            format!("{:?}", self.role_name),
+            format!("{:?}", self.identity_id).into(),
+            format!("{:?}", self.identity_type).into(),
+            format!("{:?}", self.role_name).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "identity_id".to_string(),
-            "identity_type".to_string(),
-            "role_name".to_string(),
+            "identity_id".into(),
+            "identity_type".into(),
+            "role_name".into(),
         ]
     }
 }
@@ -3044,23 +3044,23 @@ impl std::fmt::Display for OrganizationUpdate {
 
 impl tabled::Tabled for OrganizationUpdate {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(description) = &self.description {
-                format!("{:?}", description)
+                format!("{:?}", description).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["description".to_string(), "name".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["description".into(), "name".into()]
     }
 }
 
@@ -3094,25 +3094,25 @@ impl std::fmt::Display for Project {
 
 impl tabled::Tabled for Project {
     const LENGTH: usize = 6;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            format!("{:?}", self.id),
-            self.name.clone(),
-            format!("{:?}", self.organization_id),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
+            self.description.clone().into(),
+            format!("{:?}", self.id).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.organization_id).into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "id".to_string(),
-            "name".to_string(),
-            "organization_id".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
+            "description".into(),
+            "id".into(),
+            "name".into(),
+            "organization_id".into(),
+            "time_created".into(),
+            "time_modified".into(),
         ]
     }
 }
@@ -3139,12 +3139,12 @@ impl std::fmt::Display for ProjectCreate {
 
 impl tabled::Tabled for ProjectCreate {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![self.description.clone(), self.name.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![self.description.clone().into(), self.name.clone().into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["description".to_string(), "name".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["description".into(), "name".into()]
     }
 }
 
@@ -3199,19 +3199,19 @@ impl crate::types::paginate::Pagination for ProjectResultsPage {
 
 impl tabled::Tabled for ProjectResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -3261,12 +3261,12 @@ impl std::fmt::Display for ProjectRolePolicy {
 
 impl tabled::Tabled for ProjectRolePolicy {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.role_assignments)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![format!("{:?}", self.role_assignments).into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["role_assignments".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["role_assignments".into()]
     }
 }
 
@@ -3293,19 +3293,19 @@ impl std::fmt::Display for ProjectRoleRoleAssignment {
 
 impl tabled::Tabled for ProjectRoleRoleAssignment {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.identity_id),
-            format!("{:?}", self.identity_type),
-            format!("{:?}", self.role_name),
+            format!("{:?}", self.identity_id).into(),
+            format!("{:?}", self.identity_type).into(),
+            format!("{:?}", self.role_name).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "identity_id".to_string(),
-            "identity_type".to_string(),
-            "role_name".to_string(),
+            "identity_id".into(),
+            "identity_type".into(),
+            "role_name".into(),
         ]
     }
 }
@@ -3333,23 +3333,23 @@ impl std::fmt::Display for ProjectUpdate {
 
 impl tabled::Tabled for ProjectUpdate {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(description) = &self.description {
-                format!("{:?}", description)
+                format!("{:?}", description).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["description".to_string(), "name".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["description".into(), "name".into()]
     }
 }
 
@@ -3378,20 +3378,16 @@ impl std::fmt::Display for Rack {
 
 impl tabled::Tabled for Rack {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.id),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
+            format!("{:?}", self.id).into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "id".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["id".into(), "time_created".into(), "time_modified".into()]
     }
 }
 
@@ -3446,19 +3442,19 @@ impl crate::types::paginate::Pagination for RackResultsPage {
 
 impl tabled::Tabled for RackResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -3484,12 +3480,12 @@ impl std::fmt::Display for Role {
 
 impl tabled::Tabled for Role {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![self.description.clone(), self.name.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![self.description.clone().into(), self.name.clone().into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["description".to_string(), "name".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["description".into(), "name".into()]
     }
 }
 
@@ -3544,19 +3540,19 @@ impl crate::types::paginate::Pagination for RoleResultsPage {
 
 impl tabled::Tabled for RoleResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -3643,31 +3639,31 @@ impl std::fmt::Display for RouterRoute {
 
 impl tabled::Tabled for RouterRoute {
     const LENGTH: usize = 9;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            format!("{:?}", self.destination),
-            format!("{:?}", self.id),
-            format!("{:?}", self.kind),
-            self.name.clone(),
-            format!("{:?}", self.target),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
-            format!("{:?}", self.vpc_router_id),
+            self.description.clone().into(),
+            format!("{:?}", self.destination).into(),
+            format!("{:?}", self.id).into(),
+            format!("{:?}", self.kind).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.target).into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
+            format!("{:?}", self.vpc_router_id).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "destination".to_string(),
-            "id".to_string(),
-            "kind".to_string(),
-            "name".to_string(),
-            "target".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
-            "vpc_router_id".to_string(),
+            "description".into(),
+            "destination".into(),
+            "id".into(),
+            "kind".into(),
+            "name".into(),
+            "target".into(),
+            "time_created".into(),
+            "time_modified".into(),
+            "vpc_router_id".into(),
         ]
     }
 }
@@ -3698,21 +3694,21 @@ impl std::fmt::Display for RouterRouteCreateParams {
 
 impl tabled::Tabled for RouterRouteCreateParams {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            format!("{:?}", self.destination),
-            self.name.clone(),
-            format!("{:?}", self.target),
+            self.description.clone().into(),
+            format!("{:?}", self.destination).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.target).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "destination".to_string(),
-            "name".to_string(),
-            "target".to_string(),
+            "description".into(),
+            "destination".into(),
+            "name".into(),
+            "target".into(),
         ]
     }
 }
@@ -3797,19 +3793,19 @@ impl crate::types::paginate::Pagination for RouterRouteResultsPage {
 
 impl tabled::Tabled for RouterRouteResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -3840,29 +3836,29 @@ impl std::fmt::Display for RouterRouteUpdateParams {
 
 impl tabled::Tabled for RouterRouteUpdateParams {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(description) = &self.description {
-                format!("{:?}", description)
+                format!("{:?}", description).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.destination),
+            format!("{:?}", self.destination).into(),
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            format!("{:?}", self.target),
+            format!("{:?}", self.target).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "destination".to_string(),
-            "name".to_string(),
-            "target".to_string(),
+            "description".into(),
+            "destination".into(),
+            "name".into(),
+            "target".into(),
         ]
     }
 }
@@ -3887,12 +3883,15 @@ impl std::fmt::Display for Saga {
 
 impl tabled::Tabled for Saga {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.id), format!("{:?}", self.state)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            format!("{:?}", self.id).into(),
+            format!("{:?}", self.state).into(),
+        ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["id".to_string(), "state".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["id".into(), "state".into()]
     }
 }
 
@@ -3970,19 +3969,19 @@ impl crate::types::paginate::Pagination for SagaResultsPage {
 
 impl tabled::Tabled for SagaResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -4050,39 +4049,39 @@ impl std::fmt::Display for SamlIdentityProvider {
 
 impl tabled::Tabled for SamlIdentityProvider {
     const LENGTH: usize = 11;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.acs_url.clone(),
-            self.description.clone(),
-            format!("{:?}", self.id),
-            self.idp_entity_id.clone(),
-            self.name.clone(),
+            self.acs_url.clone().into(),
+            self.description.clone().into(),
+            format!("{:?}", self.id).into(),
+            self.idp_entity_id.clone().into(),
+            self.name.clone().into(),
             if let Some(public_cert) = &self.public_cert {
-                format!("{:?}", public_cert)
+                format!("{:?}", public_cert).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.slo_url.clone(),
-            self.sp_client_id.clone(),
-            self.technical_contact_email.clone(),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
+            self.slo_url.clone().into(),
+            self.sp_client_id.clone().into(),
+            self.technical_contact_email.clone().into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "acs_url".to_string(),
-            "description".to_string(),
-            "id".to_string(),
-            "idp_entity_id".to_string(),
-            "name".to_string(),
-            "public_cert".to_string(),
-            "slo_url".to_string(),
-            "sp_client_id".to_string(),
-            "technical_contact_email".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
+            "acs_url".into(),
+            "description".into(),
+            "id".into(),
+            "idp_entity_id".into(),
+            "name".into(),
+            "public_cert".into(),
+            "slo_url".into(),
+            "sp_client_id".into(),
+            "technical_contact_email".into(),
+            "time_created".into(),
+            "time_modified".into(),
         ]
     }
 }
@@ -4124,35 +4123,35 @@ impl std::fmt::Display for SamlIdentityProviderCreate {
 
 impl tabled::Tabled for SamlIdentityProviderCreate {
     const LENGTH: usize = 9;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.acs_url.clone(),
-            self.description.clone(),
-            self.idp_entity_id.clone(),
-            format!("{:?}", self.idp_metadata_source),
-            self.name.clone(),
+            self.acs_url.clone().into(),
+            self.description.clone().into(),
+            self.idp_entity_id.clone().into(),
+            format!("{:?}", self.idp_metadata_source).into(),
+            self.name.clone().into(),
             if let Some(signing_keypair) = &self.signing_keypair {
-                format!("{:?}", signing_keypair)
+                format!("{:?}", signing_keypair).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.slo_url.clone(),
-            self.sp_client_id.clone(),
-            self.technical_contact_email.clone(),
+            self.slo_url.clone().into(),
+            self.sp_client_id.clone().into(),
+            self.technical_contact_email.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "acs_url".to_string(),
-            "description".to_string(),
-            "idp_entity_id".to_string(),
-            "idp_metadata_source".to_string(),
-            "name".to_string(),
-            "signing_keypair".to_string(),
-            "slo_url".to_string(),
-            "sp_client_id".to_string(),
-            "technical_contact_email".to_string(),
+            "acs_url".into(),
+            "description".into(),
+            "idp_entity_id".into(),
+            "idp_metadata_source".into(),
+            "name".into(),
+            "signing_keypair".into(),
+            "slo_url".into(),
+            "sp_client_id".into(),
+            "technical_contact_email".into(),
         ]
     }
 }
@@ -4190,27 +4189,27 @@ impl std::fmt::Display for Silo {
 
 impl tabled::Tabled for Silo {
     const LENGTH: usize = 7;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            format!("{:?}", self.discoverable),
-            format!("{:?}", self.id),
-            self.name.clone(),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
-            format!("{:?}", self.user_provision_type),
+            self.description.clone().into(),
+            format!("{:?}", self.discoverable).into(),
+            format!("{:?}", self.id).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
+            format!("{:?}", self.user_provision_type).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "discoverable".to_string(),
-            "id".to_string(),
-            "name".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
-            "user_provision_type".to_string(),
+            "description".into(),
+            "discoverable".into(),
+            "id".into(),
+            "name".into(),
+            "time_created".into(),
+            "time_modified".into(),
+            "user_provision_type".into(),
         ]
     }
 }
@@ -4240,21 +4239,21 @@ impl std::fmt::Display for SiloCreate {
 
 impl tabled::Tabled for SiloCreate {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            format!("{:?}", self.discoverable),
-            self.name.clone(),
-            format!("{:?}", self.user_provision_type),
+            self.description.clone().into(),
+            format!("{:?}", self.discoverable).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.user_provision_type).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "discoverable".to_string(),
-            "name".to_string(),
-            "user_provision_type".to_string(),
+            "description".into(),
+            "discoverable".into(),
+            "name".into(),
+            "user_provision_type".into(),
         ]
     }
 }
@@ -4310,19 +4309,19 @@ impl crate::types::paginate::Pagination for SiloResultsPage {
 
 impl tabled::Tabled for SiloResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -4372,12 +4371,12 @@ impl std::fmt::Display for SiloRolePolicy {
 
 impl tabled::Tabled for SiloRolePolicy {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.role_assignments)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![format!("{:?}", self.role_assignments).into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["role_assignments".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["role_assignments".into()]
     }
 }
 
@@ -4404,19 +4403,19 @@ impl std::fmt::Display for SiloRoleRoleAssignment {
 
 impl tabled::Tabled for SiloRoleRoleAssignment {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.identity_id),
-            format!("{:?}", self.identity_type),
-            format!("{:?}", self.role_name),
+            format!("{:?}", self.identity_id).into(),
+            format!("{:?}", self.identity_type).into(),
+            format!("{:?}", self.role_name).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "identity_id".to_string(),
-            "identity_type".to_string(),
-            "role_name".to_string(),
+            "identity_id".into(),
+            "identity_type".into(),
+            "role_name".into(),
         ]
     }
 }
@@ -4447,21 +4446,21 @@ impl std::fmt::Display for Sled {
 
 impl tabled::Tabled for Sled {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.id),
-            self.service_address.clone(),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
+            format!("{:?}", self.id).into(),
+            self.service_address.clone().into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "id".to_string(),
-            "service_address".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
+            "id".into(),
+            "service_address".into(),
+            "time_created".into(),
+            "time_modified".into(),
         ]
     }
 }
@@ -4517,19 +4516,19 @@ impl crate::types::paginate::Pagination for SledResultsPage {
 
 impl tabled::Tabled for SledResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -4566,29 +4565,29 @@ impl std::fmt::Display for Snapshot {
 
 impl tabled::Tabled for Snapshot {
     const LENGTH: usize = 8;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            format!("{:?}", self.disk_id),
-            format!("{:?}", self.id),
-            self.name.clone(),
-            format!("{:?}", self.project_id),
-            format!("{:?}", self.size),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
+            self.description.clone().into(),
+            format!("{:?}", self.disk_id).into(),
+            format!("{:?}", self.id).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.project_id).into(),
+            format!("{:?}", self.size).into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "disk_id".to_string(),
-            "id".to_string(),
-            "name".to_string(),
-            "project_id".to_string(),
-            "size".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
+            "description".into(),
+            "disk_id".into(),
+            "id".into(),
+            "name".into(),
+            "project_id".into(),
+            "size".into(),
+            "time_created".into(),
+            "time_modified".into(),
         ]
     }
 }
@@ -4617,20 +4616,16 @@ impl std::fmt::Display for SnapshotCreate {
 
 impl tabled::Tabled for SnapshotCreate {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            self.disk.clone(),
-            self.name.clone(),
+            self.description.clone().into(),
+            self.disk.clone().into(),
+            self.name.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "description".to_string(),
-            "disk".to_string(),
-            "name".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["description".into(), "disk".into(), "name".into()]
     }
 }
 
@@ -4685,19 +4680,19 @@ impl crate::types::paginate::Pagination for SnapshotResultsPage {
 
 impl tabled::Tabled for SnapshotResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -4720,12 +4715,12 @@ impl std::fmt::Display for SpoofLoginBody {
 
 impl tabled::Tabled for SpoofLoginBody {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![self.username.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![self.username.clone().into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["username".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["username".into()]
     }
 }
 
@@ -4762,27 +4757,27 @@ impl std::fmt::Display for SshKey {
 
 impl tabled::Tabled for SshKey {
     const LENGTH: usize = 7;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            format!("{:?}", self.id),
-            self.name.clone(),
-            self.public_key.clone(),
-            format!("{:?}", self.silo_user_id),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
+            self.description.clone().into(),
+            format!("{:?}", self.id).into(),
+            self.name.clone().into(),
+            self.public_key.clone().into(),
+            format!("{:?}", self.silo_user_id).into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "id".to_string(),
-            "name".to_string(),
-            "public_key".to_string(),
-            "silo_user_id".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
+            "description".into(),
+            "id".into(),
+            "name".into(),
+            "public_key".into(),
+            "silo_user_id".into(),
+            "time_created".into(),
+            "time_modified".into(),
         ]
     }
 }
@@ -4811,20 +4806,16 @@ impl std::fmt::Display for SshKeyCreate {
 
 impl tabled::Tabled for SshKeyCreate {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            self.name.clone(),
-            self.public_key.clone(),
+            self.description.clone().into(),
+            self.name.clone().into(),
+            self.public_key.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "description".to_string(),
-            "name".to_string(),
-            "public_key".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["description".into(), "name".into(), "public_key".into()]
     }
 }
 
@@ -4879,19 +4870,19 @@ impl crate::types::paginate::Pagination for SshKeyResultsPage {
 
 impl tabled::Tabled for SshKeyResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -4920,21 +4911,21 @@ impl std::fmt::Display for TimeseriesSchema {
 
 impl tabled::Tabled for TimeseriesSchema {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.created),
-            format!("{:?}", self.datum_type),
-            format!("{:?}", self.field_schema),
-            self.timeseries_name.clone(),
+            format!("{:?}", self.created).into(),
+            format!("{:?}", self.datum_type).into(),
+            format!("{:?}", self.field_schema).into(),
+            self.timeseries_name.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "created".to_string(),
-            "datum_type".to_string(),
-            "field_schema".to_string(),
-            "timeseries_name".to_string(),
+            "created".into(),
+            "datum_type".into(),
+            "field_schema".into(),
+            "timeseries_name".into(),
         ]
     }
 }
@@ -4990,19 +4981,19 @@ impl crate::types::paginate::Pagination for TimeseriesSchemaResultsPage {
 
 impl tabled::Tabled for TimeseriesSchemaResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -5028,12 +5019,15 @@ impl std::fmt::Display for User {
 
 impl tabled::Tabled for User {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![self.display_name.clone(), format!("{:?}", self.id)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            self.display_name.clone().into(),
+            format!("{:?}", self.id).into(),
+        ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["display_name".to_string(), "id".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["display_name".into(), "id".into()]
     }
 }
 
@@ -5066,23 +5060,23 @@ impl std::fmt::Display for UserBuiltin {
 
 impl tabled::Tabled for UserBuiltin {
     const LENGTH: usize = 5;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            format!("{:?}", self.id),
-            self.name.clone(),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
+            self.description.clone().into(),
+            format!("{:?}", self.id).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "id".to_string(),
-            "name".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
+            "description".into(),
+            "id".into(),
+            "name".into(),
+            "time_created".into(),
+            "time_modified".into(),
         ]
     }
 }
@@ -5138,19 +5132,19 @@ impl crate::types::paginate::Pagination for UserBuiltinResultsPage {
 
 impl tabled::Tabled for UserBuiltinResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -5228,19 +5222,19 @@ impl crate::types::paginate::Pagination for UserResultsPage {
 
 impl tabled::Tabled for UserResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -5282,31 +5276,31 @@ impl std::fmt::Display for Vpc {
 
 impl tabled::Tabled for Vpc {
     const LENGTH: usize = 9;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            self.dns_name.clone(),
-            format!("{:?}", self.id),
-            self.ipv_6_prefix.clone(),
-            self.name.clone(),
-            format!("{:?}", self.project_id),
-            format!("{:?}", self.system_router_id),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
+            self.description.clone().into(),
+            self.dns_name.clone().into(),
+            format!("{:?}", self.id).into(),
+            self.ipv_6_prefix.clone().into(),
+            self.name.clone().into(),
+            format!("{:?}", self.project_id).into(),
+            format!("{:?}", self.system_router_id).into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "dns_name".to_string(),
-            "id".to_string(),
-            "ipv_6_prefix".to_string(),
-            "name".to_string(),
-            "project_id".to_string(),
-            "system_router_id".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
+            "description".into(),
+            "dns_name".into(),
+            "id".into(),
+            "ipv_6_prefix".into(),
+            "name".into(),
+            "project_id".into(),
+            "system_router_id".into(),
+            "time_created".into(),
+            "time_modified".into(),
         ]
     }
 }
@@ -5342,25 +5336,25 @@ impl std::fmt::Display for VpcCreate {
 
 impl tabled::Tabled for VpcCreate {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            self.dns_name.clone(),
+            self.description.clone().into(),
+            self.dns_name.clone().into(),
             if let Some(ipv_6_prefix) = &self.ipv_6_prefix {
-                format!("{:?}", ipv_6_prefix)
+                format!("{:?}", ipv_6_prefix).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.name.clone(),
+            self.name.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "dns_name".to_string(),
-            "ipv_6_prefix".to_string(),
-            "name".to_string(),
+            "description".into(),
+            "dns_name".into(),
+            "ipv_6_prefix".into(),
+            "name".into(),
         ]
     }
 }
@@ -5408,37 +5402,37 @@ impl std::fmt::Display for VpcFirewallRule {
 
 impl tabled::Tabled for VpcFirewallRule {
     const LENGTH: usize = 12;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.action),
-            self.description.clone(),
-            format!("{:?}", self.direction),
-            format!("{:?}", self.filters),
-            format!("{:?}", self.id),
-            self.name.clone(),
-            format!("{:?}", self.priority),
-            format!("{:?}", self.status),
-            format!("{:?}", self.targets),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
-            format!("{:?}", self.vpc_id),
+            format!("{:?}", self.action).into(),
+            self.description.clone().into(),
+            format!("{:?}", self.direction).into(),
+            format!("{:?}", self.filters).into(),
+            format!("{:?}", self.id).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.priority).into(),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.targets).into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
+            format!("{:?}", self.vpc_id).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "action".to_string(),
-            "description".to_string(),
-            "direction".to_string(),
-            "filters".to_string(),
-            "id".to_string(),
-            "name".to_string(),
-            "priority".to_string(),
-            "status".to_string(),
-            "targets".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
-            "vpc_id".to_string(),
+            "action".into(),
+            "description".into(),
+            "direction".into(),
+            "filters".into(),
+            "id".into(),
+            "name".into(),
+            "priority".into(),
+            "status".into(),
+            "targets".into(),
+            "time_created".into(),
+            "time_modified".into(),
+            "vpc_id".into(),
         ]
     }
 }
@@ -5515,32 +5509,28 @@ impl std::fmt::Display for VpcFirewallRuleFilter {
 
 impl tabled::Tabled for VpcFirewallRuleFilter {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(hosts) = &self.hosts {
-                format!("{:?}", hosts)
+                format!("{:?}", hosts).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(ports) = &self.ports {
-                format!("{:?}", ports)
+                format!("{:?}", ports).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(protocols) = &self.protocols {
-                format!("{:?}", protocols)
+                format!("{:?}", protocols).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "hosts".to_string(),
-            "ports".to_string(),
-            "protocols".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["hosts".into(), "ports".into(), "protocols".into()]
     }
 }
 
@@ -5675,29 +5665,29 @@ impl std::fmt::Display for VpcFirewallRuleUpdate {
 
 impl tabled::Tabled for VpcFirewallRuleUpdate {
     const LENGTH: usize = 8;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.action),
-            self.description.clone(),
-            format!("{:?}", self.direction),
-            format!("{:?}", self.filters),
-            self.name.clone(),
-            format!("{:?}", self.priority),
-            format!("{:?}", self.status),
-            format!("{:?}", self.targets),
+            format!("{:?}", self.action).into(),
+            self.description.clone().into(),
+            format!("{:?}", self.direction).into(),
+            format!("{:?}", self.filters).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.priority).into(),
+            format!("{:?}", self.status).into(),
+            format!("{:?}", self.targets).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "action".to_string(),
-            "description".to_string(),
-            "direction".to_string(),
-            "filters".to_string(),
-            "name".to_string(),
-            "priority".to_string(),
-            "status".to_string(),
-            "targets".to_string(),
+            "action".into(),
+            "description".into(),
+            "direction".into(),
+            "filters".into(),
+            "name".into(),
+            "priority".into(),
+            "status".into(),
+            "targets".into(),
         ]
     }
 }
@@ -5722,12 +5712,12 @@ impl std::fmt::Display for VpcFirewallRuleUpdateParams {
 
 impl tabled::Tabled for VpcFirewallRuleUpdateParams {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.rules)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![format!("{:?}", self.rules).into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["rules".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["rules".into()]
     }
 }
 
@@ -5751,12 +5741,12 @@ impl std::fmt::Display for VpcFirewallRules {
 
 impl tabled::Tabled for VpcFirewallRules {
     const LENGTH: usize = 1;
-    fn fields(&self) -> Vec<String> {
-        vec![format!("{:?}", self.rules)]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![format!("{:?}", self.rules).into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["rules".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["rules".into()]
     }
 }
 
@@ -5811,19 +5801,19 @@ impl crate::types::paginate::Pagination for VpcResultsPage {
 
 impl tabled::Tabled for VpcResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -5859,27 +5849,27 @@ impl std::fmt::Display for VpcRouter {
 
 impl tabled::Tabled for VpcRouter {
     const LENGTH: usize = 7;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            format!("{:?}", self.id),
-            format!("{:?}", self.kind),
-            self.name.clone(),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
-            format!("{:?}", self.vpc_id),
+            self.description.clone().into(),
+            format!("{:?}", self.id).into(),
+            format!("{:?}", self.kind).into(),
+            self.name.clone().into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
+            format!("{:?}", self.vpc_id).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "id".to_string(),
-            "kind".to_string(),
-            "name".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
-            "vpc_id".to_string(),
+            "description".into(),
+            "id".into(),
+            "kind".into(),
+            "name".into(),
+            "time_created".into(),
+            "time_modified".into(),
+            "vpc_id".into(),
         ]
     }
 }
@@ -5906,12 +5896,12 @@ impl std::fmt::Display for VpcRouterCreate {
 
 impl tabled::Tabled for VpcRouterCreate {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
-        vec![self.description.clone(), self.name.clone()]
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
+        vec![self.description.clone().into(), self.name.clone().into()]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["description".to_string(), "name".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["description".into(), "name".into()]
     }
 }
 
@@ -5988,19 +5978,19 @@ impl crate::types::paginate::Pagination for VpcRouterResultsPage {
 
 impl tabled::Tabled for VpcRouterResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -6027,23 +6017,23 @@ impl std::fmt::Display for VpcRouterUpdate {
 
 impl tabled::Tabled for VpcRouterUpdate {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(description) = &self.description {
-                format!("{:?}", description)
+                format!("{:?}", description).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["description".to_string(), "name".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["description".into(), "name".into()]
     }
 }
 
@@ -6084,29 +6074,29 @@ impl std::fmt::Display for VpcSubnet {
 
 impl tabled::Tabled for VpcSubnet {
     const LENGTH: usize = 8;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            format!("{:?}", self.id),
-            self.ipv_4_block.clone(),
-            self.ipv_6_block.clone(),
-            self.name.clone(),
-            format!("{:?}", self.time_created),
-            format!("{:?}", self.time_modified),
-            format!("{:?}", self.vpc_id),
+            self.description.clone().into(),
+            format!("{:?}", self.id).into(),
+            self.ipv_4_block.clone().into(),
+            self.ipv_6_block.clone().into(),
+            self.name.clone().into(),
+            format!("{:?}", self.time_created).into(),
+            format!("{:?}", self.time_modified).into(),
+            format!("{:?}", self.vpc_id).into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "id".to_string(),
-            "ipv_4_block".to_string(),
-            "ipv_6_block".to_string(),
-            "name".to_string(),
-            "time_created".to_string(),
-            "time_modified".to_string(),
-            "vpc_id".to_string(),
+            "description".into(),
+            "id".into(),
+            "ipv_4_block".into(),
+            "ipv_6_block".into(),
+            "name".into(),
+            "time_created".into(),
+            "time_modified".into(),
+            "vpc_id".into(),
         ]
     }
 }
@@ -6143,25 +6133,25 @@ impl std::fmt::Display for VpcSubnetCreate {
 
 impl tabled::Tabled for VpcSubnetCreate {
     const LENGTH: usize = 4;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            self.description.clone(),
-            self.ipv_4_block.clone(),
+            self.description.clone().into(),
+            self.ipv_4_block.clone().into(),
             if let Some(ipv_6_block) = &self.ipv_6_block {
-                format!("{:?}", ipv_6_block)
+                format!("{:?}", ipv_6_block).into()
             } else {
-                String::new()
+                String::new().into()
             },
-            self.name.clone(),
+            self.name.clone().into(),
         ]
     }
 
-    fn headers() -> Vec<String> {
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            "description".to_string(),
-            "ipv_4_block".to_string(),
-            "ipv_6_block".to_string(),
-            "name".to_string(),
+            "description".into(),
+            "ipv_4_block".into(),
+            "ipv_6_block".into(),
+            "name".into(),
         ]
     }
 }
@@ -6217,19 +6207,19 @@ impl crate::types::paginate::Pagination for VpcSubnetResultsPage {
 
 impl tabled::Tabled for VpcSubnetResultsPage {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
-            format!("{:?}", self.items),
+            format!("{:?}", self.items).into(),
             if let Some(next_page) = &self.next_page {
-                format!("{:?}", next_page)
+                format!("{:?}", next_page).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["items".to_string(), "next_page".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["items".into(), "next_page".into()]
     }
 }
 
@@ -6256,23 +6246,23 @@ impl std::fmt::Display for VpcSubnetUpdate {
 
 impl tabled::Tabled for VpcSubnetUpdate {
     const LENGTH: usize = 2;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(description) = &self.description {
-                format!("{:?}", description)
+                format!("{:?}", description).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec!["description".to_string(), "name".to_string()]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["description".into(), "name".into()]
     }
 }
 
@@ -6301,32 +6291,28 @@ impl std::fmt::Display for VpcUpdate {
 
 impl tabled::Tabled for VpcUpdate {
     const LENGTH: usize = 3;
-    fn fields(&self) -> Vec<String> {
+    fn fields(&self) -> Vec<std::borrow::Cow<'static, str>> {
         vec![
             if let Some(description) = &self.description {
-                format!("{:?}", description)
+                format!("{:?}", description).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(dns_name) = &self.dns_name {
-                format!("{:?}", dns_name)
+                format!("{:?}", dns_name).into()
             } else {
-                String::new()
+                String::new().into()
             },
             if let Some(name) = &self.name {
-                format!("{:?}", name)
+                format!("{:?}", name).into()
             } else {
-                String::new()
+                String::new().into()
             },
         ]
     }
 
-    fn headers() -> Vec<String> {
-        vec![
-            "description".to_string(),
-            "dns_name".to_string(),
-            "name".to_string(),
-        ]
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec!["description".into(), "dns_name".into(), "name".into()]
     }
 }
 


### PR DESCRIPTION
This changes some of the Tabled trait type signatures to return copy-on-write strings. They're more efficient because they can be a reference to a static string. In many places in this PR I'm just using cloned owned strings instead of references to static strings, but this will do for now. In the future we can improve it.