### PR TITLE
Users can customize the reqwest client

### DIFF
--- a/openapitor/src/client.rs
+++ b/openapitor/src/client.rs
@@ -196,12 +196,15 @@ pub struct Client {
 }
 
 impl Client {
+    #[tracing::instrument]
     /// Create a new Client struct. It takes a type that can convert into
     /// an &str (`String` or `Vec<u8>` for example). As long as the function is
     /// given a valid API key your requests will work.
-    #[tracing::instrument]
-    pub fn new<T>(
+    /// Also takes reqwest client builders, for customizing the client's behaviour.
+    pub fn new_from_reqwest<T>(
         token: T,
+        builder_http: reqwest::ClientBuilder,
+        builder_websocket: reqwest::ClientBuilder,
     ) -> Self
     where
         T: ToString + std::fmt::Debug,
@@ -209,20 +212,7 @@ impl Client {
         // Retry up to 3 times with increasing intervals between attempts.
         let retry_policy =
             reqwest_retry::policies::ExponentialBackoff::builder().build_with_max_retries(3);
-        let client = reqwest::Client::builder()
-            .user_agent(APP_USER_AGENT)
-            // For file conversions we need this to be long.
-            .timeout(std::time::Duration::from_secs(TIMEOUT_NUM_SECONDS))
-            .connect_timeout(std::time::Duration::from_secs(60))
-            .build();
-        let client_http1 = reqwest::Client::builder()
-            // For file conversions we need this to be long.
-            .user_agent(APP_USER_AGENT)
-            .timeout(std::time::Duration::from_secs(TIMEOUT_NUM_SECONDS))
-            .connect_timeout(std::time::Duration::from_secs(60))
-            .http1_only()
-            .build();
-        match (client, client_http1) {
+        match (builder_http.build(), builder_websocket.build()) {
             (Ok(c), Ok(c1)) => {
                 let client = reqwest_middleware::ClientBuilder::new(c)
                     // Trace HTTP requests. See the tracing crate to make use of these traces.
@@ -242,7 +232,7 @@ impl Client {
                     .build();
                 Client {
                     token: token.to_string(),
-                    base_url: "BASE_URL".to_string(),
+                    base_url: "https://api.kittycad.io".to_string(),
 
                     client,
                     client_http1_only,
@@ -250,6 +240,28 @@ impl Client {
             }
             (Err(e), _) | (_, Err(e)) => panic!("creating reqwest client failed: {:?}", e),
         }
+    }
+
+    /// Create a new Client struct. It takes a type that can convert into
+    /// an &str (`String` or `Vec<u8>` for example). As long as the function is
+    /// given a valid API key your requests will work.
+    #[tracing::instrument]
+    pub fn new<T>(token: T) -> Self
+    where
+        T: ToString + std::fmt::Debug,
+    {
+        let client = reqwest::Client::builder()
+            .user_agent(APP_USER_AGENT)
+            // For file conversions we need this to be long.
+            .timeout(std::time::Duration::from_secs(600))
+            .connect_timeout(std::time::Duration::from_secs(60));
+        let client_http1 = reqwest::Client::builder()
+            // For file conversions we need this to be long.
+            .user_agent(APP_USER_AGENT)
+            .timeout(std::time::Duration::from_secs(600))
+            .connect_timeout(std::time::Duration::from_secs(60))
+            .http1_only();
+        Self::new_from_reqwest(token, client, client_http1)
     }
 
     /// Set the base URL for the client to something other than the default: <BASE_URL>.


### PR DESCRIPTION
Sometimes users will want to set custom headers, or other HTTP settings. They should be able to. Easiest way is to just let them pass in their own reqwest client with whatever settings they choose.

The particular motivating use-case is that our API monitor needs to send slightly different headers, so that the API knows this request comes from the monitoring suite.