### PR TITLE
Bump schemars to 0.8.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7b0ce13155372a76ee2e1c5ffba1fe61ede73fbea5630d61eee6fac4929c0c"
+checksum = "45a28f4c49489add4ce10783f7911893516f15afe45d015608d41faca6bc4d29"
 dependencies = [
  "bigdecimal",
  "bytes",
@@ -1845,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85e2a16b12bdb763244c69ab79363d71db2b4b918a2def53f80b02e0574b13c"
+checksum = "c767fd6fa65d9ccf9cf026122c1b555f2ef9a4f0cea69da4d7dbc3e258d30967"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/kittycad/Cargo.toml
+++ b/kittycad/Cargo.toml
@@ -31,7 +31,7 @@ reqwest-conditional-middleware = { version = "0.2.1", optional = true }
 reqwest-middleware = { version = "0.2.2", optional = true }
 reqwest-retry = { version = "0.2.2", optional = true }
 reqwest-tracing = { version = "0.4.4", features = ["opentelemetry_0_17"], optional = true }
-schemars = { version = "0.8.15", features = ["bigdecimal04", "bytes", "chrono", "url", "uuid1"] }
+schemars = { version = "0.8.16", features = ["bigdecimal04", "bytes", "chrono", "url", "uuid1"] }
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = "1"

--- a/openapitor/src/lib.rs
+++ b/openapitor/src/lib.rs
@@ -594,7 +594,7 @@ reqwest-conditional-middleware = {{ version = "0.2.1", optional = true }}
 reqwest-middleware = {{ version = "0.2.2", optional = true }}
 reqwest-retry = {{ version = "0.2.2", optional = true }}
 reqwest-tracing = {{ version = "0.4.4", features = ["opentelemetry_0_17"], optional = true }}
-schemars = {{ version = "0.8.15", features = ["bigdecimal04", "bytes", "chrono", "url", "uuid1"] }}
+schemars = {{ version = "0.8.16", features = ["bigdecimal04", "bytes", "chrono", "url", "uuid1"] }}
 serde = {{ version = "1", features = ["derive"] }}
 serde_bytes = "0.11"
 serde_json = "1"


### PR DESCRIPTION
The schemars maintainer recently released 0.8.16 which dramatically reduces the amount of LLVM large enums generate. This makes kittycad.rs compile 35% faster in release mode!