### PR TITLE
Include body text in UnexpectedResponse

### DIFF
--- a/kittycad/src/executor.rs
+++ b/kittycad/src/executor.rs
@@ -89,11 +89,22 @@ impl Executor {
                 ),
             );
         let resp = req.send().await?;
+        let headers = resp.headers().clone();
         if resp.status().is_client_error() || resp.status().is_server_error() {
-            return Err(crate::types::error::Error::UnexpectedResponse(resp));
+            let status = resp.status();
+            let url = resp.url().to_string();
+            let body = resp
+                .text()
+                .await
+                .unwrap_or_else(|_| "<error reading body>".to_owned());
+            return Err(crate::types::error::Error::UnexpectedResponse {
+                url,
+                status,
+                body,
+                headers,
+            });
         }
 
-        let headers = resp.headers().clone();
         let upgraded = resp
             .upgrade()
             .await

--- a/kittycad/src/ml.rs
+++ b/kittycad/src/ml.rs
@@ -857,11 +857,22 @@ impl Ml {
                 ),
             );
         let resp = req.send().await?;
+        let headers = resp.headers().clone();
         if resp.status().is_client_error() || resp.status().is_server_error() {
-            return Err(crate::types::error::Error::UnexpectedResponse(resp));
+            let status = resp.status();
+            let url = resp.url().to_string();
+            let body = resp
+                .text()
+                .await
+                .unwrap_or_else(|_| "<error reading body>".to_owned());
+            return Err(crate::types::error::Error::UnexpectedResponse {
+                url,
+                status,
+                body,
+                headers,
+            });
         }
 
-        let headers = resp.headers().clone();
         let upgraded = resp
             .upgrade()
             .await
@@ -898,11 +909,22 @@ impl Ml {
                 ),
             );
         let resp = req.send().await?;
+        let headers = resp.headers().clone();
         if resp.status().is_client_error() || resp.status().is_server_error() {
-            return Err(crate::types::error::Error::UnexpectedResponse(resp));
+            let status = resp.status();
+            let url = resp.url().to_string();
+            let body = resp
+                .text()
+                .await
+                .unwrap_or_else(|_| "<error reading body>".to_owned());
+            return Err(crate::types::error::Error::UnexpectedResponse {
+                url,
+                status,
+                body,
+                headers,
+            });
         }
 
-        let headers = resp.headers().clone();
         let upgraded = resp
             .upgrade()
             .await

--- a/kittycad/src/modeling.rs
+++ b/kittycad/src/modeling.rs
@@ -133,11 +133,22 @@ impl Modeling {
                 ),
             );
         let resp = req.send().await?;
+        let headers = resp.headers().clone();
         if resp.status().is_client_error() || resp.status().is_server_error() {
-            return Err(crate::types::error::Error::UnexpectedResponse(resp));
+            let status = resp.status();
+            let url = resp.url().to_string();
+            let body = resp
+                .text()
+                .await
+                .unwrap_or_else(|_| "<error reading body>".to_owned());
+            return Err(crate::types::error::Error::UnexpectedResponse {
+                url,
+                status,
+                body,
+                headers,
+            });
         }
 
-        let headers = resp.headers().clone();
         let upgraded = resp
             .upgrade()
             .await

--- a/kittycad/src/tests.rs
+++ b/kittycad/src/tests.rs
@@ -560,9 +560,8 @@ async fn test_modeling_websocket() {
         .await
     {
         Ok((ws, _headers)) => ws,
-        Err(crate::types::error::Error::UnexpectedResponse(resp)) => {
-            let txt = resp.text().await.unwrap();
-            panic!("Failed to connect to modeling websocket: {txt}");
+        Err(crate::types::error::Error::UnexpectedResponse { body, .. }) => {
+            panic!("Failed to connect to modeling websocket: {body}");
         }
         err => panic!("Failed to connect to modeling websocket: {err:?}"),
     };

--- a/kittycad/src/types.rs
+++ b/kittycad/src/types.rs
@@ -396,7 +396,16 @@ pub mod error {
         },
         #[doc = " A response not listed in the API description. This may represent a"]
         #[doc = " success or failure response; check `status().is_success()`."]
-        UnexpectedResponse(reqwest::Response),
+        UnexpectedResponse {
+            #[doc = " HTTP status response code from server"]
+            status: reqwest::StatusCode,
+            #[doc = " URL that caused the error."]
+            url: String,
+            #[doc = " HTTP response body from the server, rendered as text."]
+            body: String,
+            #[doc = " HTTP headers"]
+            headers: reqwest::header::HeaderMap,
+        },
     }
 
     impl Error {
@@ -412,7 +421,7 @@ pub mod error {
                 Error::SerdeError { error: _, status } => Some(*status),
                 Error::InvalidResponsePayload { error: _, response } => Some(response.status()),
                 Error::Server { body: _, status } => Some(*status),
-                Error::UnexpectedResponse(r) => Some(r.status()),
+                Error::UnexpectedResponse { status, .. } => Some(*status),
             }
         }
 
@@ -469,8 +478,17 @@ pub mod error {
                 Error::Server { body, status } => {
                     write!(f, "Server Error: {} {}", status, body)
                 }
-                Error::UnexpectedResponse(r) => {
-                    write!(f, "Unexpected Response: {:?}", r)
+                Error::UnexpectedResponse {
+                    headers,
+                    status,
+                    body,
+                    url,
+                } => {
+                    write!(
+                        f,
+                        "Unexpected Response for {url} (HTTP {}). Headers: {:?}, body: {}",
+                        status, headers, body
+                    )
                 }
             }
         }

--- a/openapitor/src/functions.rs
+++ b/openapitor/src/functions.rs
@@ -104,11 +104,14 @@ fn generate_websocket_fn(
         #websocket_headers
 
         let resp = req.send().await?;
+        let headers = resp.headers().clone();
         if resp.status().is_client_error() || resp.status().is_server_error() {
-            return Err(crate::types::error::Error::UnexpectedResponse(resp));
+            let status = resp.status();
+            let url = resp.url().to_string();
+            let body = resp.text().await.unwrap_or_else(|_| "<error reading body>".to_owned());
+            return Err(crate::types::error::Error::UnexpectedResponse{url, status, body, headers});
         }
 
-        let headers = resp.headers().clone();
         // TODO: This isn't really a request error, but the response was already consumed.
         // So we can't use Error::UnexpectedResponse.
         let upgraded = resp.upgrade().await.map_err(crate::types::error::Error::RequestError)?;

--- a/openapitor/src/types/error.rs
+++ b/openapitor/src/types/error.rs
@@ -42,7 +42,16 @@ pub enum Error {
 
     /// A response not listed in the API description. This may represent a
     /// success or failure response; check `status().is_success()`.
-    UnexpectedResponse(reqwest::Response),
+    UnexpectedResponse {
+        /// HTTP status response code from server
+        status: reqwest::StatusCode,
+        /// URL that caused the error.
+        url: String,
+        /// HTTP response body from the server, rendered as text.
+        body: String,
+        /// HTTP headers
+        headers: reqwest::header::HeaderMap,
+    },
 }
 
 impl Error {
@@ -58,7 +67,7 @@ impl Error {
             Error::SerdeError { error: _, status } => Some(*status),
             Error::InvalidResponsePayload { error: _, response } => Some(response.status()),
             Error::Server { body: _, status } => Some(*status),
-            Error::UnexpectedResponse(r) => Some(r.status()),
+            Error::UnexpectedResponse { status, .. } => Some(*status),
         }
     }
 
@@ -115,8 +124,17 @@ impl std::fmt::Display for Error {
             Error::Server { body, status } => {
                 write!(f, "Server Error: {} {}", status, body)
             }
-            Error::UnexpectedResponse(r) => {
-                write!(f, "Unexpected Response: {:?}", r)
+            Error::UnexpectedResponse {
+                headers,
+                status,
+                body,
+                url,
+            } => {
+                write!(
+                    f,
+                    "Unexpected Response for {url} (HTTP {}). Headers: {:?}, body: {}",
+                    status, headers, body
+                )
             }
         }
     }

--- a/openapitor/tests/types/kittycad.rs.gen
+++ b/openapitor/tests/types/kittycad.rs.gen
@@ -391,7 +391,16 @@ pub mod error {
         },
         #[doc = " A response not listed in the API description. This may represent a"]
         #[doc = " success or failure response; check `status().is_success()`."]
-        UnexpectedResponse(reqwest::Response),
+        UnexpectedResponse {
+            #[doc = " HTTP status response code from server"]
+            status: reqwest::StatusCode,
+            #[doc = " URL that caused the error."]
+            url: String,
+            #[doc = " HTTP response body from the server, rendered as text."]
+            body: String,
+            #[doc = " HTTP headers"]
+            headers: reqwest::header::HeaderMap,
+        },
     }
 
     impl Error {
@@ -407,7 +416,7 @@ pub mod error {
                 Error::SerdeError { error: _, status } => Some(*status),
                 Error::InvalidResponsePayload { error: _, response } => Some(response.status()),
                 Error::Server { body: _, status } => Some(*status),
-                Error::UnexpectedResponse(r) => Some(r.status()),
+                Error::UnexpectedResponse { status, .. } => Some(*status),
             }
         }
 
@@ -464,8 +473,17 @@ pub mod error {
                 Error::Server { body, status } => {
                     write!(f, "Server Error: {} {}", status, body)
                 }
-                Error::UnexpectedResponse(r) => {
-                    write!(f, "Unexpected Response: {:?}", r)
+                Error::UnexpectedResponse {
+                    headers,
+                    status,
+                    body,
+                    url,
+                } => {
+                    write!(
+                        f,
+                        "Unexpected Response for {url} (HTTP {}). Headers: {:?}, body: {}",
+                        status, headers, body
+                    )
                 }
             }
         }

--- a/openapitor/tests/types/oxide.rs.gen
+++ b/openapitor/tests/types/oxide.rs.gen
@@ -391,7 +391,16 @@ pub mod error {
         },
         #[doc = " A response not listed in the API description. This may represent a"]
         #[doc = " success or failure response; check `status().is_success()`."]
-        UnexpectedResponse(reqwest::Response),
+        UnexpectedResponse {
+            #[doc = " HTTP status response code from server"]
+            status: reqwest::StatusCode,
+            #[doc = " URL that caused the error."]
+            url: String,
+            #[doc = " HTTP response body from the server, rendered as text."]
+            body: String,
+            #[doc = " HTTP headers"]
+            headers: reqwest::header::HeaderMap,
+        },
     }
 
     impl Error {
@@ -407,7 +416,7 @@ pub mod error {
                 Error::SerdeError { error: _, status } => Some(*status),
                 Error::InvalidResponsePayload { error: _, response } => Some(response.status()),
                 Error::Server { body: _, status } => Some(*status),
-                Error::UnexpectedResponse(r) => Some(r.status()),
+                Error::UnexpectedResponse { status, .. } => Some(*status),
             }
         }
 
@@ -464,8 +473,17 @@ pub mod error {
                 Error::Server { body, status } => {
                     write!(f, "Server Error: {} {}", status, body)
                 }
-                Error::UnexpectedResponse(r) => {
-                    write!(f, "Unexpected Response: {:?}", r)
+                Error::UnexpectedResponse {
+                    headers,
+                    status,
+                    body,
+                    url,
+                } => {
+                    write!(
+                        f,
+                        "Unexpected Response for {url} (HTTP {}). Headers: {:?}, body: {}",
+                        status, headers, body
+                    )
                 }
             }
         }

--- a/openapitor/tests/types/websocket.rs.gen
+++ b/openapitor/tests/types/websocket.rs.gen
@@ -27,10 +27,21 @@ pub async fn example_api_websocket_counter<'a>(
             ),
         );
     let resp = req.send().await?;
-    if resp.status().is_client_error() || resp.status().is_server_error() {
-        return Err(crate::types::error::Error::UnexpectedResponse(resp));
-    }
     let headers = resp.headers().clone();
+    if resp.status().is_client_error() || resp.status().is_server_error() {
+        let status = resp.status();
+        let url = resp.url().to_string();
+        let body = resp
+            .text()
+            .await
+            .unwrap_or_else(|_| "<error reading body>".to_owned());
+        return Err(crate::types::error::Error::UnexpectedResponse {
+            url,
+            status,
+            body,
+            headers,
+        });
+    }
     let upgraded = resp
         .upgrade()
         .await


### PR DESCRIPTION
Currently if Kittycad.rs (or any other crate generated by OpenAPItor) has an unexpected HTTP response, the error only contains the HTTP header data (e.g. the URL, status code, etc).

We'd like it to include the full body response too, because that's frequently where the actual error is sent back. It's hard to debug without that data.

This came up while debugging an issue in the Zoo Synera node, and without this information, it's hard to understand the error.