### PR TITLE
ci: Change to run all tests instead of failing fast

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -36,10 +36,11 @@ jobs:
       - name: cargo test
         shell: bash
         run: |
-          cargo llvm-cov nextest --all --lcov --output-path lcov.info --all-features
-          cargo llvm-cov nextest --all --lcov --output-path lcov.info
+          cargo llvm-cov nextest --all --lcov --output-path lcov.info --no-fail-fast --all-features
+          cargo llvm-cov nextest --all --lcov --output-path lcov.info --no-fail-fast
         env:
           KITTYCAD_API_TOKEN: ${{secrets.KITTYCAD_API_TOKEN}}
+          RUST_BACKTRACE: full
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v7


### PR DESCRIPTION
CI was exiting early after the first failing test.